### PR TITLE
Fixes a crash due to missing mode with WHDload

### DIFF
--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -152,14 +152,14 @@ struct my_openfile_s *my_open (const TCHAR *name, int flags)
     {
         write_log(_T("Creating new file:\n"));
         write_log(name);
-        write_log('\n');
+        write_log(_T("\n"));
         mos->h = reinterpret_cast<void *>(open(name, flags, 0660));
     }
     else
     {
         write_log(_T("Opening file:\n"));
         write_log(name);
-        write_log('\n');
+        write_log(_T("\n"));
         mos->h = reinterpret_cast<void *>(open(name, flags));
     }
     if (!mos->h)

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -148,7 +148,20 @@ struct my_openfile_s *my_open (const TCHAR *name, int flags)
     mos = xmalloc (struct my_openfile_s, 1);
     if (!mos)
         return nullptr;
-    mos->h = reinterpret_cast<void *>(open(name, flags));
+    if(flags & O_CREAT)
+    {
+        write_log(_T("Creating new file:\n"));
+        write_log(name);
+        write_log('\n');
+        mos->h = reinterpret_cast<void *>(open(name, flags, 0660));
+    }
+    else
+    {
+        write_log(_T("Opening file:\n"));
+        write_log(name);
+        write_log('\n');
+        mos->h = reinterpret_cast<void *>(open(name, flags));
+    }
     if (!mos->h)
     {
         xfree (mos);


### PR DESCRIPTION
See documentation for open:
https://linux.die.net/man/2/open

> mode specifies the permissions to use in case a new file is created. This argument must be supplied when O_CREAT is specified in flags; if O_CREAT is not specified, then mode is ignored. The effective permissions are modified by the process's umask in the usual way: The permissions of the created file are (mode & ~umask). Note that this mode only applies to future accesses of the newly created file; the open() call that creates a read-only file may well return a read/write file descriptor.