### PR TITLE
amiberry_gfx: fix sdl2-dispmanx build

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -16,11 +16,11 @@
 
 #include <png.h>
 #include <SDL.h>
+#include <cmath>
 #ifdef USE_SDL1
 #include <SDL_image.h>
 #include <SDL_gfxPrimitives.h>
 #include <SDL_ttf.h>
- #include <cmath>
 #endif
 #ifdef ANDROIDSDL
 #include <SDL_screenkeyboard.h>


### PR DESCRIPTION
std::ceil requires cmath header to build correctly on Raspbian Jessie (gcc 4.9.2).