### PR TITLE
Support standalone (single button) retroarch hotkeys for quit/menu/reset

### DIFF
--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -1052,9 +1052,27 @@ static void read_joystick(void)
 
 			auto held_offset = 0;
 
-
-			// temporary solution for retroarch buttons inc. HOTKEY 
-			if (SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.hotkey_button) & 1)
+			// detect standalone retroarch hotkeys
+			if (current_controller_map.hotkey_button == -1)
+			{
+				if (current_controller_map.menu_button != -1)
+				{
+					setjoybuttonstate(hostjoyid + 1, 14,
+						(SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.menu_button) & 1));
+				}
+				if (current_controller_map.quit_button != -1)
+				{
+					setjoybuttonstate(hostjoyid + 1, 15,
+						(SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.quit_button) & 1));
+				}
+				if (current_controller_map.reset_button != -1)
+				{
+					setjoybuttonstate(hostjoyid + 1, 30,
+						(SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.reset_button) & 1));
+				}
+			}
+			// temporary solution for retroarch buttons inc. HOTKEY
+			else if (SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.hotkey_button) & 1)
 			{
 				held_offset = REMAP_BUTTONS;
 				setjoybuttonstate(hostjoyid + 1, 14,


### PR DESCRIPTION
Fixes standalone retroarch hotkeys for quit/menu/reset.

Changes proposed in this pull request:
- In Retroarch it's possible to set the "input_enable_hotkey_btn" to "nul", which means you no longer have to hold down a button first before being able to use the other retroarch hotkey buttons. This is useful if you have a dedicated button on your arcade cab for exiting the current game, for example. This code change detects if you don't have anything bound to the hotkey enable button and allows any bound standalone buttons to work.

@midwan
