### PR TITLE
Added path to SDL_ttf.h and SDL_image.h in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ USE_SDL2 = 1
 else ifeq ($(PLATFORM),vero4k)
 USE_SDL2 = 1
     CPU_FLAGS += -march=armv8-a -mtune=cortex-a53 -mfpu=neon-fp-armv8
-    CFLAGS += -I/opt/vero3/include -DARMV6T2 -DUSE_ARMNEON -DARM_HAS_DIV -DUSE_SDL2 -DMALI_GPU -DUSE_RENDER_THREAD -DTINKER
+    CFLAGS += -I/opt/vero3/include -I/usr/include/SDL2 -DARMV6T2 -DUSE_ARMNEON -DARM_HAS_DIV -DUSE_SDL2 -DMALI_GPU -DUSE_RENDER_THREAD -DTINKER
     LDFLAGS += -L/opt/vero3/lib
     HAVE_NEON = 1
     NAME  = amiberry-vero4k


### PR DESCRIPTION
Fixes # .

> ./include/guisan/sdl/sdltruetypefont.hpp:50:21: fatal error: SDL_ttf.h: No such file or directory
>  #include <SDL_ttf.h>

and
> src/sdl/sdlimageloader.cpp:63:23: fatal error: SDL_image.h: No such file or directory
>  #include "SDL_image.h"

when building on Vero4k.

Changes proposed in this pull request:

Add `/usr/include/SDL2/` to the include path for Vero4k.
As per [your comment here](https://github.com/midwan/amiberry/issues/160#issuecomment-349559724) this is the correct place to find them.  I see now that some other platforms are requiring the same in the Makefile.

Not sure why the system doesn't find them itself, nor why this wasn't a problem when I was building Amiberry previously.  Maybe I had something in the environment pointing the way that shouldn't be there in a clean install?

Many thanks.
@midwan
