### PR TITLE
fix sdl1 build

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -673,7 +673,9 @@ static void open_screen(struct uae_prefs* p)
 void update_display(struct uae_prefs* p)
 {
 	open_screen(p);
+	#ifdef USE_SDL1
 	SDL_SetRelativeMouseMode(SDL_TRUE);
+	#endif
 	SDL_ShowCursor(SDL_DISABLE);
 	framecnt = 1; // Don't draw frame before reset done
 }

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -359,7 +359,9 @@ namespace sdl
 		check_error_sdl(gui_texture == nullptr, "Unable to create GUI texture");
 
 		SDL_ShowCursor(SDL_ENABLE);
+		#ifdef USE_SDL1
 		SDL_SetRelativeMouseMode(SDL_FALSE);
+		#endif
 #endif
 #ifdef ANDROIDSDL
 		// Enable Android multitouch


### PR DESCRIPTION
SDL_SetRelativeMouseMode applies only to sdl1

@midwan
