### PR TITLE
WHDLoad Booter additional downloads (#435)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -469,7 +469,7 @@ void print_usage()
 	printf("\nUsage:\n");
 	printf(" -f <file>                  Load a configuration file.\n");
 	printf(" -config=<file>             Load a configuration file.\n");
-	printf(" -autowhdload=<file>        Load a WHDLoad game pack.\n");
+	printf(" -autoload=<file>           Load a WHDLoad game or .CUE CD32 image.\n");
 	printf(" -statefile=<file>          Load a save state file.\n");
 	printf(" -s <config param>=<value>  Set the configuration parameter with value.\n");
 	printf("                            Edit a configuration file in order to know valid parameters and settings.\n");
@@ -694,6 +694,23 @@ void leave_program (void)
     do_leave_program ();
 }
 
+bool check_internet_connection()
+{
+	auto result = false;
+	FILE *output;
+
+	if (!((output = popen("/sbin/route -n | grep -c '^0\\.0\\.0\\.0'", "r"))))
+		return result;
+
+	unsigned int i;
+	fscanf(output, "%u", &i);
+	if (i == 1)
+		result = true; // There is internet connection
+	else if (i == 0)
+		result = false; // There is no internet connection
+	pclose(output);
+	return result;
+}
 
 // In case of error, print the error code and close the application
 void check_error_sdl(const bool check, const char* message) {

--- a/src/osdep/gui/PanelPaths.cpp
+++ b/src/osdep/gui/PanelPaths.cpp
@@ -166,17 +166,62 @@ void copy_file( const char* srce_file, const char* dest_file )
     dest << srce.rdbuf() ;
 }
 
+void download_rtb(const char* download_file)
+{    
+        char download_command[MAX_DPATH];
+        char local_path[MAX_DPATH];
+    
+        //  download .rtb
+        snprintf(local_path, MAX_DPATH, "%s/whdboot/save-data/Kickstarts/%s", start_path_data,download_file);                                
+        snprintf(download_command, MAX_DPATH, "wget -np -nv -O %s https://github.com/midwan/amiberry/blob/master/whdboot/save-data/Kickstarts/%s?raw=true",local_path,download_file);                
+        if (!zfile_exists(local_path)) // ?? 
+        {   auto afile = popen(download_command, "r");
+            write_log("Downloading %s ...\n", download_file);
+            pclose(afile);
+        }
+}
+
 class DownloadXMLButtonActionListener : public gcn::ActionListener
 {
 public:
 	void action(const gcn::ActionEvent& actionEvent) override
 	{
+		if (!check_internet_connection())
+		{
+			ShowMessage("No Internet Connection", "No Internet Connection was found!", "Please connect to the Internet then try again.", "OK", "");
+			return;
+		}
+
 		char original_date[MAX_DPATH] = "2000-01-01 at 00:00:01\n";
 		char updated_date[MAX_DPATH] = "2000-01-01 at 00:00:01\n";
-
+                
 		char xml_path[MAX_DPATH];
 		char xml2_path[MAX_DPATH];
-
+                char download_command[MAX_DPATH];
+                
+                //  download WHDLOAD
+ 		snprintf(xml_path, MAX_DPATH, "%s/whdboot/WHDLoad", start_path_data);                                
+                snprintf(download_command, MAX_DPATH, "wget -np -nv -O %s https://github.com/midwan/amiberry/blob/master/whdboot/WHDLoad?raw=true",xml_path);                
+		if (!zfile_exists(xml_path)) // ?? 
+		{   auto afile = popen(download_command, "r");
+                    pclose(afile);
+                }
+                
+                // download kickstart RTB files for maximum compatibility
+ 		snprintf(xml_path, MAX_DPATH, "kick33180.A500.RTB");                                                
+                download_rtb(xml_path);                        
+ 		snprintf(xml_path, MAX_DPATH, "kick33192.A500.RTB");                                                
+                download_rtb(xml_path);
+ 		snprintf(xml_path, MAX_DPATH, "kick34005.A500.RTB");                                                
+                download_rtb(xml_path);                
+ 		snprintf(xml_path, MAX_DPATH, "kick40063.A600.RTB");                                                
+                download_rtb(xml_path);
+ 		snprintf(xml_path, MAX_DPATH, "kick40068.A1200.RTB");                                                
+                download_rtb(xml_path);
+ 		snprintf(xml_path, MAX_DPATH, "kick40068.A4000.RTB");                                                
+                download_rtb(xml_path);                
+                
+                //
 		snprintf(xml_path, MAX_DPATH, "%s/whdboot/game-data/whdload_db.xml", start_path_data);
 		snprintf(xml2_path, MAX_DPATH, "/tmp/whdload_db.xml");
 
@@ -224,7 +269,7 @@ public:
 		}
 		else
 		{
-			ShowMessage("XML Downloader", "Local XML does not require update.", "", "Ok", "");
+			ShowMessage("XML Downloader", "Local XML is the current version.", "", "Ok", "");
 		}
 
 		// show message depending on what was done		

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -195,4 +195,6 @@ extern int delay_savestate_frame;
 
 extern void UpdateGuiScreen();
 
+extern bool check_internet_connection();
+
 #endif // GUI_HANDLING_H


### PR DESCRIPTION
* Bugfix for 2nd controller selection

* ignore netbeans project

* Add experimental `-autocd=` loading of files (.cue works very well - .iso should also)

* CD Autoloading adapted to include .uae file check and hostconf controller options

* Beginning of Booter Panel implentation

* Booter Panel development .. start on XML reading for picked LHA file

* New WHDLoad booter, included updated boot-data.zip, plus new hostprefs FIXED_HEIGHT= option and bugfixes for XML reading, and symlink ROM scan. Plus updated XML

* Upload of .RTB files that need to accompany the Symlinked Kickstarts, for WHDLoad compatibility.

* Allows for additional libraries from `boot-data.zip` to be linked on load, to aid compatibility (e.g. Dungeon Master), plus new XML

* Fix hardware settings tab issues from XML reading, plus additional write_log reports for debugging WHD booter.

* Code cleanup (non-essential)

* XML Download button added to paths panel including date checking

* WHDLoad local copy

* Added check for internet connectivity before downloading XML

* Updated button to download WHDLoad and .RTB files (if not present) with XML file.

Fixes # .

Changes proposed in this pull request:
-
-
-

@midwan
