### PR TITLE
Fix #492.  Init Joysticks earlier under SDL2.  Build for armv7 on Vero4k.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ AARCH64 = 1
 
 else ifeq ($(PLATFORM),vero4k)
 USE_SDL2 = 1
-    CFLAGS += -march=armv8-a -mtune=cortex-a53 -mfpu=neon-fp-armv8
+    CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations
     CPPFLAGS += -I/opt/vero3/include -DARMV6_ASSEMBLY -D_FILE_OFFSET_BITS=64 -DARMV6T2 -DUSE_ARMNEON -DARM_HAS_DIV -DUSE_SDL2 -DMALI_GPU -DUSE_RENDER_THREAD -DFASTERCYCLES
     LDFLAGS += -L/opt/vero3/lib
     HAVE_NEON = 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -731,12 +731,18 @@ static int real_main2 (int argc, TCHAR **argv)
 {
 #ifdef USE_SDL1
 	int ret = SDL_Init(SDL_INIT_NOPARACHUTE | SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK);
+#elif USE_SDL2
+	// Some gamepads need this extra time to come up or they wont be detected
+	int ret = SDL_Init(SDL_INIT_JOYSTICK); // Init everything else later when we need it
+#endif
+#if defined (USE_SDL1) || defined (USE_SDL2)
 	if (ret < 0)
 	{
 		printf("SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
 		abort();
 	}
 #endif
+
 	keyboard_settrans();
 	set_config_changed();
 	if (restart_config[0]) {

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -341,7 +341,7 @@ int graphics_setup(void)
 		}
 	}
 #elif USE_SDL2
-	if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
+	if (SDL_Init(SDL_INIT_EVERYTHING & ~SDL_INIT_JOYSTICK) != 0) // Everything except joystick, which was initialised earlier
 	{
 		SDL_Log("SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
 		abort();


### PR DESCRIPTION
@midwan
Fixes #492 

It appears that a few controllers require a bit longer to come up to speed than others.
By the time the config is loaded at startup and tries to use the specified controller it isn't ready yet and the settings are ignored.
By the time manual loading of the config is attempted via the GUI the controller is good to go.

---
Changes proposed in this pull request:

The affected controllers were ok under SDL1.
With the move to SDL2 the initialisation happens during a later graphics setup phase.  I'm sure there are reasons why it was moved and it's been mostly harmless taking the joystick initialisation with it.
My change is to separately initialise the joystick subsystem at the earlier time that was proven to work for SLD1.2 and then initialise everything else later.

As an aside I'm now building for armv7 on the Vero4k as that's the native binary userland in operation there under OSMC.  We do not suffer any noticeable performance loss and in some cases it has solved bugs.

Many thanks,
