### PR TITLE
README.md | Add libraspberrypi-dev to as RPi-specific build dependency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ For the Odroid XU4
 
 For the ASUS Tinker board
 
-      make -j6 PLATFORM=tinker
+      make -j6 PLATFORM=RK3328
 
 For the Odroid C1
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@ Amiberry has been tested on Debian/Raspbian Buster, and requires the following p
 If you want to compile Amiberry from source, you'll need the `-dev` version of the same packages instead:
 
       sudo apt-get install libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libxml2-dev libflac-dev libmpg123-dev libpng-dev libmpeg2-4-dev
+      # On Raspberry Pi, additionally:
+      sudo apt-get install libraspberrypi-dev
 
 # Getting Amiberry
 


### PR DESCRIPTION
Due to:
```
g++ -mcpu=arm1176jzf-s -mfpu=vfp -Ofast -pipe -Wno-shift-overflow -Wno-narrowing  -std=gnu++14 -MD -MT src/inputdevice.o -MF src/inputdevice.d -DARMV6_ASSEMBLY -D_FILE_OFFSET_BITS=64 -DARMV6T2 -DUSE_DISPMANX -I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/include/interface/vcos/pthreads  -I/usr/local/include/SDL2 -D_REENTRANT -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -I/usr/include/libxml2 -DAMIBERRY  -c -o src/inputdevice.o src/inputdevice.cpp
In file included from src/inputdevice.cpp:39:
src/osdep/amiberry_gfx.h:5:10: fatal error: bcm_host.h: No such file or directory
 #include <bcm_host.h>
          ^~~~~~~~~~~~
compilation terminated.
```
`/opt/vc/include` is part of the `libraspberrypi-dev` package.

Could be added in a visually different way, so in case take it as a hint only 😉.

Signed-off-by: MichaIng <micha@dietpi.com>