### PR TITLE
Fixes to allow Retroarch Keyboard as Joystick to work as > 1 joystick.

### DIFF
--- a/src/include/inputdevice.h
+++ b/src/include/inputdevice.h
@@ -58,6 +58,11 @@ extern struct inputdevice_functions inputdevicefunc_joystick;
 extern struct inputdevice_functions inputdevicefunc_mouse;
 extern struct inputdevice_functions inputdevicefunc_keyboard;
 extern int pause_emulation;
+extern int num_keys_as_joys;
+extern int input_default_mouse_speed ;
+extern int input_keyboard_as_joystick_stop_keypresses ;
+
+extern bool KeyUsedInPluggedInRetroarchJoystick(int scancode) ;
 
 struct uae_input_device_default_node
 {
@@ -441,6 +446,10 @@ struct host_keyboard_button {
 	int start_button;
 	int lstick_button;
 	int rstick_button;
+	
+	int hotkey_button;
+	int quit_button;
+	int menu_button;
 
 	bool is_retroarch;
 };

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -110,6 +110,9 @@ static int bouncy;
 static signed long bouncy_cycles;
 static int autopause;
 
+int input_default_mouse_speed = 100 ;
+int input_keyboard_as_joystick_stop_keypresses = 0 ;
+
 #define HANDLE_IE_FLAG_CANSTOPPLAYBACK 1
 #define HANDLE_IE_FLAG_PLAYBACKEVENT 2
 #define HANDLE_IE_FLAG_AUTOFIRE 4
@@ -6971,7 +6974,7 @@ void inputdevice_default_prefs (struct uae_prefs *p)
 	p->input_joymouse_speed = 10;
 	p->input_analog_joystick_mult = 15;
 	p->input_analog_joystick_offset = -1;
-	p->input_mouse_speed = 100;
+	p->input_mouse_speed = input_default_mouse_speed;
 	p->input_autofire_linecnt = 0; //8 * 312; // Disable Autofire by default
 	p->input_keyboard_type = 0;
 	p->input_autoswitch = true;

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -57,6 +57,9 @@ static bool canjit (void)
 		return false;
 	return true;
 }
+#ifdef DEBUG
+bool jit_direct_compatible_memory = false ;
+#endif
 static bool needmman (void)
 {
 	if (!jit_direct_compatible_memory)

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -1027,6 +1027,11 @@ void load_amiberry_settings(void)
 					cfgfile_intval(option, value, "speedup_timelimit_nonjit", &speedup_timelimit_nonjit, 1);
 					cfgfile_intval(option, value, "speedup_timelimit_jit_turbo", &speedup_timelimit_jit_turbo, 1);
 					cfgfile_intval(option, value, "speedup_timelimit_nonjit_turbo", &speedup_timelimit_nonjit_turbo, 1);
+
+					// 
+					cfgfile_intval(option, value, "input_default_mouse_speed", &input_default_mouse_speed,1);
+					cfgfile_intval(option, value, "input_keyboard_as_joystick_stop_keypresses", &input_keyboard_as_joystick_stop_keypresses,1);
+					
 				}
 			}
 		}
@@ -1201,97 +1206,114 @@ int handle_msgpump()
 			break;
 
 		case SDL_KEYDOWN:
-			if (rEvent.key.repeat == 0)
 			{
-				// If the Enter GUI key was pressed, handle it
-				if (enter_gui_key && rEvent.key.keysym.sym == enter_gui_key)
+				// if the key belongs to a "retro arch joystick" ignore it
+				// ONLY when in game though, we need to remove the joysticks really 
+				// if we want to use the KB
+				// i've added this so when using the joysticks it doesnt hit the 'r' key for some games
+				// which starts a replay!!!
+				bool b_ok_to_use = !KeyUsedInPluggedInRetroarchJoystick(rEvent.key.keysym.scancode) ;
+				if ( b_ok_to_use )
 				{
-					inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
-					break;
-				}
-
-				// If the Quit emulator key was pressed, handle it
-				if (quit_key && rEvent.key.keysym.sym == quit_key)
-				{
-					inputdevice_add_inputcode(AKS_QUIT, 1, nullptr);
-					break;
-				}
-
-				if (action_replay_button && rEvent.key.keysym.sym == action_replay_button)
-				{
-					inputdevice_add_inputcode(AKS_FREEZEBUTTON, 1, nullptr);
-					break;
-				}
-
-				if (fullscreen_key && rEvent.key.keysym.sym == fullscreen_key)
-				{
-					inputdevice_add_inputcode(AKS_TOGGLEWINDOWEDFULLSCREEN, 1, nullptr);
-					break;
-				}
-			}
-			// If the reset combination was pressed, handle it
-			if (swap_win_alt_keys)
-			{
-				if (keystate[SDL_SCANCODE_LCTRL] && keystate[SDL_SCANCODE_LALT] && (keystate[SDL_SCANCODE_RALT] || keystate[SDL_SCANCODE_APPLICATION]))
-				{
-					uae_reset(0, 1);
-					break;
-				}
-			}
-			else if (keystate[SDL_SCANCODE_LCTRL] && keystate[SDL_SCANCODE_LGUI] && (keystate[SDL_SCANCODE_RGUI] || keystate[SDL_SCANCODE_APPLICATION]))
-			{
-				uae_reset(0, 1);
-				break;
-			}
-
-			if (rEvent.key.repeat == 0)
-			{
-				if (rEvent.key.keysym.sym == SDLK_CAPSLOCK)
-				{
-					// Treat CAPSLOCK as a toggle. If on, set off and vice/versa
-					ioctl(0, KDGKBLED, &kbd_flags);
-					ioctl(0, KDGETLED, &kbd_led_status);
-					if (kbd_flags & 07 & LED_CAP)
+					if (rEvent.key.repeat == 0)
 					{
-						// On, so turn off
-						kbd_led_status &= ~LED_CAP;
-						kbd_flags &= ~LED_CAP;
-						inputdevice_do_keyboard(AK_CAPSLOCK, 0);
-					}
-					else
-					{
-						// Off, so turn on
-						kbd_led_status |= LED_CAP;
-						kbd_flags |= LED_CAP;
-						inputdevice_do_keyboard(AK_CAPSLOCK, 1);
-					}
-					ioctl(0, KDSETLED, kbd_led_status);
-					ioctl(0, KDSKBLED, kbd_flags);
-					break;
-				}
+						// If the Enter GUI key was pressed, handle it
+						if (enter_gui_key && rEvent.key.keysym.sym == enter_gui_key)
+						{
+							inputdevice_add_inputcode(AKS_ENTERGUI, 1, nullptr);
+							break;
+						}
 
-				// Handle all other keys
-				if (swap_win_alt_keys)
-				{
-					if (rEvent.key.keysym.scancode == SDL_SCANCODE_LALT)
-						rEvent.key.keysym.scancode = SDL_SCANCODE_LGUI;
-					else if (rEvent.key.keysym.scancode == SDL_SCANCODE_RALT)
-						rEvent.key.keysym.scancode = SDL_SCANCODE_RGUI;
+						// If the Quit emulator key was pressed, handle it
+						if (quit_key && rEvent.key.keysym.sym == quit_key)
+						{
+							inputdevice_add_inputcode(AKS_QUIT, 1, nullptr);
+							break;
+						}
+
+						if (action_replay_button && rEvent.key.keysym.sym == action_replay_button)
+						{
+							inputdevice_add_inputcode(AKS_FREEZEBUTTON, 1, nullptr);
+							break;
+						}
+
+						if (fullscreen_key && rEvent.key.keysym.sym == fullscreen_key)
+						{
+							inputdevice_add_inputcode(AKS_TOGGLEWINDOWEDFULLSCREEN, 1, nullptr);
+							break;
+						}
+					}
+					// If the reset combination was pressed, handle it
+					if (swap_win_alt_keys)
+					{
+						if (keystate[SDL_SCANCODE_LCTRL] && keystate[SDL_SCANCODE_LALT] && (keystate[SDL_SCANCODE_RALT] || keystate[SDL_SCANCODE_APPLICATION]))
+						{
+							uae_reset(0, 1);
+							break;
+						}
+					}
+					else if (keystate[SDL_SCANCODE_LCTRL] && keystate[SDL_SCANCODE_LGUI] && (keystate[SDL_SCANCODE_RGUI] || keystate[SDL_SCANCODE_APPLICATION]))
+					{
+						uae_reset(0, 1);
+						break;
+					}
+
+					if (rEvent.key.repeat == 0)
+					{
+						if (rEvent.key.keysym.sym == SDLK_CAPSLOCK)
+						{
+							// Treat CAPSLOCK as a toggle. If on, set off and vice/versa
+							ioctl(0, KDGKBLED, &kbd_flags);
+							ioctl(0, KDGETLED, &kbd_led_status);
+							if (kbd_flags & 07 & LED_CAP)
+							{
+								// On, so turn off
+								kbd_led_status &= ~LED_CAP;
+								kbd_flags &= ~LED_CAP;
+								inputdevice_do_keyboard(AK_CAPSLOCK, 0);
+							}
+							else
+							{
+								// Off, so turn on
+								kbd_led_status |= LED_CAP;
+								kbd_flags |= LED_CAP;
+								inputdevice_do_keyboard(AK_CAPSLOCK, 1);
+							}
+							ioctl(0, KDSETLED, kbd_led_status);
+							ioctl(0, KDSKBLED, kbd_flags);
+							break;
+						}
+
+						// Handle all other keys
+						if (swap_win_alt_keys)
+						{
+							if (rEvent.key.keysym.scancode == SDL_SCANCODE_LALT)
+								rEvent.key.keysym.scancode = SDL_SCANCODE_LGUI;
+							else if (rEvent.key.keysym.scancode == SDL_SCANCODE_RALT)
+								rEvent.key.keysym.scancode = SDL_SCANCODE_RGUI;
+						}
+						inputdevice_translatekeycode(0, rEvent.key.keysym.scancode, 1, false);
+					}
 				}
-				inputdevice_translatekeycode(0, rEvent.key.keysym.scancode, 1, false);
 			}
 			break;
 		case SDL_KEYUP:
-			if (rEvent.key.repeat == 0)
 			{
-				if (swap_win_alt_keys)
+				bool b_ok_to_use = !KeyUsedInPluggedInRetroarchJoystick(rEvent.key.keysym.scancode) ;
+				if ( b_ok_to_use )
 				{
-					if (rEvent.key.keysym.scancode == SDL_SCANCODE_LALT)
-						rEvent.key.keysym.scancode = SDL_SCANCODE_LGUI;
-					else if (rEvent.key.keysym.scancode == SDL_SCANCODE_RALT)
-						rEvent.key.keysym.scancode = SDL_SCANCODE_RGUI;
+					if (rEvent.key.repeat == 0)
+					{
+						if (swap_win_alt_keys)
+						{
+							if (rEvent.key.keysym.scancode == SDL_SCANCODE_LALT)
+								rEvent.key.keysym.scancode = SDL_SCANCODE_LGUI;
+							else if (rEvent.key.keysym.scancode == SDL_SCANCODE_RALT)
+								rEvent.key.keysym.scancode = SDL_SCANCODE_RGUI;
+						}
+						inputdevice_translatekeycode(0, rEvent.key.keysym.scancode, 0, true);
+					}
 				}
-				inputdevice_translatekeycode(0, rEvent.key.keysym.scancode, 0, true);
 			}
 			break;
 

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -26,7 +26,7 @@ const int remap_buttons = 16;
 #define SET_BIT(var,pos) ((var) |= 1 << (pos))
 
 static int num_mice = 1;
-static int num_keys_as_joys;
+int num_keys_as_joys = 0;
 
 static void fill_default_controller()
 {
@@ -148,7 +148,11 @@ static void fill_default_keyboard()
 	default_keyboard_map.select_button = SDL_SCANCODE_1;
 	default_keyboard_map.start_button = SDL_SCANCODE_2;
 	default_keyboard_map.lstick_button = SDL_SCANCODE_F1;
-	default_keyboard_map.rstick_button = SDL_SCANCODE_F2;
+	default_keyboard_map.rstick_button = SDL_SCANCODE_F2;	
+
+	default_keyboard_map.hotkey_button = -1 ;
+	default_keyboard_map.quit_button = -1 ;
+	default_keyboard_map.menu_button = -1 ;
 
 	default_keyboard_map.is_retroarch = false;
 }
@@ -562,13 +566,24 @@ bool find_retroarch_polarity(const TCHAR* find_setting, char* retroarch_file)
 	return tempbutton;
 }
 
-const TCHAR* find_retroarch_key(const TCHAR* find_setting, char* retroarch_file)
+const TCHAR* find_retroarch_key(const TCHAR* find_setting_prefix, int iPlayer, const TCHAR* suffix, char* retroarch_file)
 {
 	// opening file and parsing
 	std::ifstream read_file(retroarch_file);
 	std::string line;
 	std::string delimiter = " = ";
 	auto output = "nul";
+
+	//
+	std::string find_setting = find_setting_prefix ;
+	if ( suffix != nullptr )
+	{
+		// ad player and suffix!
+		char buffer[10] ;
+		sprintf(buffer,"%i_",iPlayer) ;
+		find_setting += buffer ;
+		find_setting += suffix ;
+	}
 
 	// read each line in
 	while (std::getline(read_file, line))
@@ -636,6 +651,124 @@ static std::string sanitize_retroarch_name(std::string s)
 	return s;
 }
 
+static bool init_kb_from_retroarch(int iIdx,char* retroarch_file)
+{
+	struct host_keyboard_button temp_keyboard_buttons{};
+	int iPlayer = (iIdx + 1) ;
+		
+	auto tempkey = find_retroarch_key("input_player",iPlayer,"y", retroarch_file);
+	auto x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.north_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"a", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.east_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"b", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.south_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"x", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.west_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"left", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.dpad_left = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"right", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.dpad_right = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"up", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.dpad_up = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"down", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.dpad_down = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"l", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.left_shoulder = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"r", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.right_shoulder = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"select", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.select_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"start", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.start_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"l2", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.lstick_button = remap_key_map_list[x];
+
+	tempkey = find_retroarch_key("input_player",iPlayer,"r2", retroarch_file);
+	x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+	temp_keyboard_buttons.rstick_button = remap_key_map_list[x];
+		
+	// Added for keyboard ability to pull up the amiberry menu which most people want!
+	if ( iIdx == 0 )
+	{
+		tempkey = find_retroarch_key("input_enable_hotkey", iPlayer,NULL, retroarch_file);
+		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+		temp_keyboard_buttons.hotkey_button = remap_key_map_list[x];
+
+		tempkey = find_retroarch_key("input_exit_emulator", iPlayer,NULL, retroarch_file);
+		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+		temp_keyboard_buttons.quit_button = remap_key_map_list[x];
+
+		tempkey = find_retroarch_key("input_menu_toggle", iPlayer,NULL, retroarch_file);
+		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
+		temp_keyboard_buttons.menu_button = remap_key_map_list[x];
+	}
+	else
+	{
+		temp_keyboard_buttons.hotkey_button = -1 ;
+		temp_keyboard_buttons.quit_button = -1 ; 
+		temp_keyboard_buttons.menu_button = -1 ;
+	}
+
+	// only accept this IF it has been setup, exit once one is missing!
+	// basically if one is set, assume it is setup for a player
+	bool bValid =		temp_keyboard_buttons.north_button		!= -1
+					||	temp_keyboard_buttons.east_button		!= -1
+					||	temp_keyboard_buttons.south_button		!= -1
+					||	temp_keyboard_buttons.west_button		!= -1
+					||	temp_keyboard_buttons.dpad_left			!= -1
+					||	temp_keyboard_buttons.dpad_right		!= -1
+					||	temp_keyboard_buttons.dpad_up			!= -1
+					||	temp_keyboard_buttons.dpad_down			!= -1
+					||	temp_keyboard_buttons.left_shoulder		!= -1
+					||	temp_keyboard_buttons.right_shoulder	!= -1
+					||	temp_keyboard_buttons.select_button		!= -1
+					||	temp_keyboard_buttons.start_button		!= -1
+					||	temp_keyboard_buttons.lstick_button		!= -1
+					||	temp_keyboard_buttons.rstick_button		!= -1 ;
+	if ( bValid )
+	{
+		//
+		temp_keyboard_buttons.is_retroarch = true;
+
+		// set it!
+		host_keyboard_buttons[iIdx] = temp_keyboard_buttons;
+
+		// and max!
+		num_keys_as_joys = iPlayer > num_keys_as_joys ? iPlayer : num_keys_as_joys ;
+	}
+
+	//
+	write_log("Controller init_kb_from_retroarch(%i): %s \n", iIdx,bValid ? "Found" : "Not found" );
+
+	//
+	return bValid ;
+}
+
 static int init_joystick()
 {
 	// we will also use this routine to grab the retroarch buttons
@@ -646,69 +779,16 @@ static int init_joystick()
 
 	if (my_existsfile(retroarch_file))
 	{
-		struct host_keyboard_button temp_keyboard_buttons{};
-
-		auto tempkey = find_retroarch_key("input_player1_y", retroarch_file);
-		auto x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.north_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_a", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.east_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_b", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.south_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_x", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.west_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_left", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.dpad_left = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_right", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.dpad_right = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_up", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.dpad_up = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_down", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.dpad_down = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_l", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.left_shoulder = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_r", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.right_shoulder = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_select", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.select_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_start", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.start_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_l3", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.lstick_button = remap_key_map_list[x];
-
-		tempkey = find_retroarch_key("input_player1_r3", retroarch_file);
-		x = find_string_in_array(remap_key_map_list_strings, remap_key_map_list_size, tempkey);
-		temp_keyboard_buttons.rstick_button = remap_key_map_list[x];
-
-		temp_keyboard_buttons.is_retroarch = true;
-		host_keyboard_buttons[0] = temp_keyboard_buttons;
-		num_keys_as_joys = 1;
+		// Add as many keyboards as joysticks that are setup
+		// on arcade machines, you could have a 4 player ipac using all keyboard buttons
+		// so you want to have at least 4 keyboards to choose from!
+		// once one config is missing, simply stop adding them!
+		bool bValid = true ;
+		for ( int kb = 0 ; kb < 4 && bValid ; ++ kb)
+		{
+			bValid = init_kb_from_retroarch(kb,retroarch_file) ;
+		}
 	}
-
 	else
 	{
 		fill_default_keyboard();
@@ -892,13 +972,13 @@ static const TCHAR* get_joystick_friendlyname(const int joy)
 		{
 			if (host_keyboard_buttons[n].is_retroarch)
 			{
-				sprintf(tmp1, "RetroArch Keyboard as Joystick [Input #%d]", n + 1);
+				sprintf(tmp1, "RetroArch Keyboard as Joystick [#%d]", n + 1);
 				return tmp1;
 			}
 			return "Keyboard as Joystick [Default]";
 		}
 	}
-	return joystick_name[joy - num_keys_as_joys];
+	return joystick_name[joy - num_keys_as_joys] ;
 }
 
 static const TCHAR* get_joystick_uniquename(const int joy)
@@ -1014,39 +1094,55 @@ static void read_joystick()
 	for (auto joyid = 0; joyid < MAX_JPORTS; joyid++)
 	{
 		// First handle retroarch (or default) keys as Joystick...
-		if (currprefs.jports[joyid].id >= JSEM_JOYS && currprefs.jports[joyid].id < JSEM_JOYS + num_keys_as_joys)
+		if (currprefs.jports[joyid].id >= JSEM_JOYS && currprefs.jports[joyid].id < (JSEM_JOYS + num_keys_as_joys) )
 		{
+			//
 			const auto hostkeyid = currprefs.jports[joyid].id - JSEM_JOYS;
 			auto keystate = SDL_GetKeyboardState(nullptr);
+			int kb = hostkeyid ;
 
 			// cd32 red, blue, green, yellow
-			setjoybuttonstate(0, 0, keystate[host_keyboard_buttons[hostkeyid].south_button]); // b
-			setjoybuttonstate(0, 1, keystate[host_keyboard_buttons[hostkeyid].east_button]); // a
-			setjoybuttonstate(0, 2, keystate[host_keyboard_buttons[hostkeyid].north_button]); //y 
-			setjoybuttonstate(0, 3, keystate[host_keyboard_buttons[hostkeyid].west_button]); // x
+			setjoybuttonstate(kb, 0, keystate[host_keyboard_buttons[kb].south_button] & 1); // b
+			setjoybuttonstate(kb, 1, keystate[host_keyboard_buttons[kb].east_button] & 1); // a
+			setjoybuttonstate(kb, 2, keystate[host_keyboard_buttons[kb].north_button] & 1); //y 
+			setjoybuttonstate(kb, 3, keystate[host_keyboard_buttons[kb].west_button] & 1); // x
 
-			setjoybuttonstate(0, 4, keystate[host_keyboard_buttons[hostkeyid].left_shoulder]); // z 
-			setjoybuttonstate(0, 5, keystate[host_keyboard_buttons[hostkeyid].right_shoulder]); // x
-			setjoybuttonstate(0, 6, keystate[host_keyboard_buttons[hostkeyid].start_button]); //num1
+			setjoybuttonstate(kb, 4, keystate[host_keyboard_buttons[kb].left_shoulder] & 1); // z 
+			setjoybuttonstate(kb, 5, keystate[host_keyboard_buttons[kb].right_shoulder] & 1); // x
+			setjoybuttonstate(kb, 6, keystate[host_keyboard_buttons[kb].start_button] & 1); //num1
 			// up down left right     
-			setjoybuttonstate(0, 7, keystate[host_keyboard_buttons[hostkeyid].dpad_up]);
-			setjoybuttonstate(0, 8, keystate[host_keyboard_buttons[hostkeyid].dpad_down]);
-			setjoybuttonstate(0, 9, keystate[host_keyboard_buttons[hostkeyid].dpad_left]);
-			setjoybuttonstate(0, 10, keystate[host_keyboard_buttons[hostkeyid].dpad_right]);
+			setjoybuttonstate(kb, 7, keystate[host_keyboard_buttons[kb].dpad_up] & 1);
+			setjoybuttonstate(kb, 8, keystate[host_keyboard_buttons[kb].dpad_down] & 1);
+			setjoybuttonstate(kb, 9, keystate[host_keyboard_buttons[kb].dpad_left] & 1);
+			setjoybuttonstate(kb, 10, keystate[host_keyboard_buttons[kb].dpad_right] & 1);
 
 			// stick left/right     
-			setjoybuttonstate(0, 11, keystate[host_keyboard_buttons[hostkeyid].lstick_button]);
-			setjoybuttonstate(0, 12, keystate[host_keyboard_buttons[hostkeyid].rstick_button]);
-			setjoybuttonstate(0, 13, keystate[host_keyboard_buttons[hostkeyid].select_button]); // num2
+			setjoybuttonstate(kb, 11, keystate[host_keyboard_buttons[kb].lstick_button] & 1);
+			setjoybuttonstate(kb, 12, keystate[host_keyboard_buttons[kb].rstick_button] & 1);
+			setjoybuttonstate(kb, 13, keystate[host_keyboard_buttons[kb].select_button] & 1); // num2
+
+			// hotkey?
+			if (keystate[host_keyboard_buttons[kb].hotkey_button] & 1)
+			{
+				//held_offset = REMAP_BUTTONS;
+				// menu button
+				setjoybuttonstate(kb, 14,keystate[host_keyboard_buttons[kb].menu_button] & 1) ;
+				// quit button
+				setjoybuttonstate(kb, 15,keystate[host_keyboard_buttons[kb].quit_button] & 1) ;
+				// reset button
+				//setjoybuttonstate(kb, 30,keystate[host_keyboard_buttons[kb].reset_button] & 1) ;
+			}
 		}
 
-			// this is what we actually use on the Pi (for joysticks :)
+		// this is what we actually use on the Pi (for joysticks :)
 		else if (jsem_isjoy(joyid, &currprefs) != -1)
 		{
 			// Now we handle real SDL joystick...
 			const auto hostjoyid = currprefs.jports[joyid].id - JSEM_JOYS - num_keys_as_joys;
 			static struct host_input_button current_controller_map;
 			current_controller_map = host_input_buttons[hostjoyid];
+
+			const auto joyOffset = num_keys_as_joys ;
 
 			if (current_controller_map.east_button == current_controller_map.hotkey_button)
 				current_controller_map.east_button = -1;
@@ -1088,19 +1184,19 @@ static void read_joystick()
 			{
 				if (current_controller_map.menu_button != -1)
 				{
-					setjoybuttonstate(hostjoyid + 1, 14,
+					setjoybuttonstate(hostjoyid + joyOffset, 14,
 					                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 					                                        current_controller_map.menu_button) & 1);
 				}
 				if (current_controller_map.quit_button != -1)
 				{
-					setjoybuttonstate(hostjoyid + 1, 15,
+					setjoybuttonstate(hostjoyid + joyOffset, 15,
 					                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 					                                        current_controller_map.quit_button) & 1);
 				}
 				if (current_controller_map.reset_button != -1)
 				{
-					setjoybuttonstate(hostjoyid + 1, 30,
+					setjoybuttonstate(hostjoyid + joyOffset, 30,
 					                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 					                                        current_controller_map.reset_button) & 1);
 				}
@@ -1109,15 +1205,15 @@ static void read_joystick()
 			else if (SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.hotkey_button) & 1)
 			{
 				held_offset = REMAP_BUTTONS;
-				setjoybuttonstate(hostjoyid + 1, 14,
+				setjoybuttonstate(hostjoyid + joyOffset, 14,
 				                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.menu_button) &
 				                  1);
 				// menu button
-				setjoybuttonstate(hostjoyid + 1, 15,
+				setjoybuttonstate(hostjoyid + joyOffset, 15,
 				                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.quit_button) &
 				                  1);
 				// quit button
-				setjoybuttonstate(hostjoyid + 1, 30,
+				setjoybuttonstate(hostjoyid + joyOffset, 30,
 				                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.reset_button) &
 				                  1);
 				// reset button
@@ -1149,37 +1245,37 @@ static void read_joystick()
 				if (current_controller_map.lstick_axis_x_invert != 0)
 					val = val * -1;
 
-				setjoystickstate(hostjoyid + 1, 0, val, upper_bound);
+				setjoystickstate(hostjoyid + joyOffset, 0, val, upper_bound);
 
 				// handle the Y axis   
 				val = SDL_JoystickGetAxis(joysticktable[hostjoyid], current_controller_map.lstick_axis_y);
 				if (current_controller_map.lstick_axis_y_invert != 0)
 					val = val * -1;
 
-				setjoystickstate(hostjoyid + 1, 1, val, upper_bound);
+				setjoystickstate(hostjoyid + joyOffset, 1, val, upper_bound);
 			}
 
 			else
 			{
 				// alternative code for custom remapping the left stick  
 				// handle the Y axis  (left stick)
-				setjoybuttonstate(hostjoyid + 1, 7 + held_offset,
+				setjoybuttonstate(hostjoyid + joyOffset, 7 + held_offset,
 				                  SDL_JoystickGetAxis(joysticktable[hostjoyid], current_controller_map.lstick_axis_y) <=
 				                  lower_bound
 					                  ? 1
 					                  : 0);
-				setjoybuttonstate(hostjoyid + 1, 8 + held_offset,
+				setjoybuttonstate(hostjoyid + joyOffset, 8 + held_offset,
 				                  SDL_JoystickGetAxis(joysticktable[hostjoyid], current_controller_map.lstick_axis_y) >=
 				                  upper_bound
 					                  ? 1
 					                  : 0);
 				// handle the X axis  
-				setjoybuttonstate(hostjoyid + 1, 9 + held_offset,
+				setjoybuttonstate(hostjoyid + joyOffset, 9 + held_offset,
 				                  SDL_JoystickGetAxis(joysticktable[hostjoyid], current_controller_map.lstick_axis_x) <=
 				                  lower_bound
 					                  ? 1
 					                  : 0);
-				setjoybuttonstate(hostjoyid + 1, 10 + held_offset,
+				setjoybuttonstate(hostjoyid + joyOffset, 10 + held_offset,
 				                  SDL_JoystickGetAxis(joysticktable[hostjoyid], current_controller_map.lstick_axis_x) >=
 				                  upper_bound
 					                  ? 1
@@ -1191,38 +1287,38 @@ static void read_joystick()
 			if (current_controller_map.rstick_axis_x_invert != 0)
 				val = val * -1;
 
-			setjoystickstate(hostjoyid + 1, 2, val, upper_bound);
+			setjoystickstate(hostjoyid + joyOffset, 2, val, upper_bound);
 
 			val = SDL_JoystickGetAxis(joysticktable[hostjoyid], current_controller_map.rstick_axis_y);
 			if (current_controller_map.rstick_axis_y_invert != 0)
 				val = val * -1;
 
-			setjoystickstate(hostjoyid + 1, 3, val, upper_bound);
+			setjoystickstate(hostjoyid + joyOffset, 3, val, upper_bound);
 
 			// cd32 red, blue, green, yellow
 			// south 
-			setjoybuttonstate(hostjoyid + 1, 0 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 0 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.south_button) & 1);
 			// east                    
-			setjoybuttonstate(hostjoyid + 1, 1 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 1 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.east_button) & 1);
 			// west
-			setjoybuttonstate(hostjoyid + 1, 2 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 2 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.west_button) & 1);
 			// north
-			setjoybuttonstate(hostjoyid + 1, 3 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 3 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.north_button) & 1);
 
 			// cd32  rwd, ffw, start
-			setjoybuttonstate(hostjoyid + 1, 4 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 4 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 			                                        current_controller_map.left_shoulder) & 1);
 			// left shoulder
-			setjoybuttonstate(hostjoyid + 1, 5 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 5 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.right_shoulder) &
 			                  1);
 			// right shoulder
-			setjoybuttonstate(hostjoyid + 1, 6 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 6 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid], current_controller_map.start_button) & 1);
 			// start
 
@@ -1230,38 +1326,38 @@ static void read_joystick()
 			// HAT Handling *or* D-PAD buttons     
 			const int hat = SDL_JoystickGetHat(joysticktable[hostjoyid], 0);
 
-			setjoybuttonstate(hostjoyid + 1, 7 + held_offset, current_controller_map.dpad_up + 1
+			setjoybuttonstate(hostjoyid + joyOffset, 7 + held_offset, current_controller_map.dpad_up + 1
 				                                                  ? SDL_JoystickGetButton(
 					                                                  joysticktable[hostjoyid],
 					                                                  current_controller_map.dpad_up) & 1
 				                                                  : hat & SDL_HAT_UP);
-			setjoybuttonstate(hostjoyid + 1, 8 + held_offset, current_controller_map.dpad_down + 1
+			setjoybuttonstate(hostjoyid + joyOffset, 8 + held_offset, current_controller_map.dpad_down + 1
 				                                                  ? SDL_JoystickGetButton(
 					                                                  joysticktable[hostjoyid],
 					                                                  current_controller_map.dpad_down) & 1
 				                                                  : hat & SDL_HAT_DOWN);
-			setjoybuttonstate(hostjoyid + 1, 9 + held_offset, current_controller_map.dpad_left + 1
+			setjoybuttonstate(hostjoyid + joyOffset, 9 + held_offset, current_controller_map.dpad_left + 1
 				                                                  ? SDL_JoystickGetButton(
 					                                                  joysticktable[hostjoyid],
 					                                                  current_controller_map.dpad_left) & 1
 				                                                  : hat & SDL_HAT_LEFT);
-			setjoybuttonstate(hostjoyid + 1, 10 + held_offset, current_controller_map.dpad_right + 1
+			setjoybuttonstate(hostjoyid + joyOffset, 10 + held_offset, current_controller_map.dpad_right + 1
 				                                                   ? SDL_JoystickGetButton(
 					                                                   joysticktable[hostjoyid],
 					                                                   current_controller_map.dpad_right) & 1
 				                                                   : hat & SDL_HAT_RIGHT);
 
 			// stick left/right/select
-			setjoybuttonstate(hostjoyid + 1, 11 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 11 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 			                                        current_controller_map.lstick_button) & 1);
 			// left stick
-			setjoybuttonstate(hostjoyid + 1, 12 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 12 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 			                                        current_controller_map.rstick_button) & 1);
 			// right stick
 
-			setjoybuttonstate(hostjoyid + 1, 13 + held_offset,
+			setjoybuttonstate(hostjoyid + joyOffset, 13 + held_offset,
 			                  SDL_JoystickGetButton(joysticktable[hostjoyid],
 			                                        current_controller_map.select_button) & 1);
 			// select button
@@ -1576,4 +1672,37 @@ int input_get_default_joystick(struct uae_input_device* uid, const int num, int 
 int input_get_default_joystick_analog(struct uae_input_device* uid, int i, int port, int af, bool gp, bool joymouseswap)
 {
 	return 0;
+}
+
+bool KeyUsedInPluggedInRetroarchJoystick(int scancode)
+{
+	bool bUsesKey = false ;
+	if ( input_keyboard_as_joystick_stop_keypresses )
+	{
+		//currprefs.jports[port]
+		for (auto joyid = 0; joyid < MAX_JPORTS && !bUsesKey; joyid++)
+		{
+			// First handle retroarch (or default) keys as Joystick...
+			if (currprefs.jports[joyid].id >= JSEM_JOYS && currprefs.jports[joyid].id < (JSEM_JOYS + num_keys_as_joys) )
+			{	
+				const auto hostkeyid = currprefs.jports[joyid].id - JSEM_JOYS;
+				int kb = hostkeyid ;
+				bUsesKey = 		host_keyboard_buttons[kb].south_button == scancode
+							||	host_keyboard_buttons[kb].east_button == scancode 
+							||	host_keyboard_buttons[kb].north_button == scancode 
+							||	host_keyboard_buttons[kb].west_button == scancode 
+							||	host_keyboard_buttons[kb].left_shoulder == scancode
+							||	host_keyboard_buttons[kb].right_shoulder == scancode
+							||	host_keyboard_buttons[kb].start_button == scancode   
+							||	host_keyboard_buttons[kb].dpad_up == scancode
+							||	host_keyboard_buttons[kb].dpad_down == scancode
+							||	host_keyboard_buttons[kb].dpad_left == scancode
+							||	host_keyboard_buttons[kb].dpad_right == scancode    
+							||	host_keyboard_buttons[kb].lstick_button == scancode
+							||	host_keyboard_buttons[kb].rstick_button == scancode
+							||	host_keyboard_buttons[kb].select_button == scancode ;		
+			}
+		}
+	}
+	return bUsesKey ;
 }

--- a/src/osdep/gui/PanelCustom.cpp
+++ b/src/osdep/gui/PanelCustom.cpp
@@ -538,9 +538,9 @@ void RefreshPanelCustom(void)
 	// update the joystick port  , and disable those which are not available
 	char tmp[255];
 
-	if (changed_prefs.jports[SelectedPort].id > JSEM_JOYS && changed_prefs.jports[SelectedPort].id < JSEM_MICE - 1)
+	if (changed_prefs.jports[SelectedPort].id >= JSEM_JOYS + num_keys_as_joys && changed_prefs.jports[SelectedPort].id < JSEM_MICE - 1)
 	{
-		const auto hostjoyid = changed_prefs.jports[SelectedPort].id - JSEM_JOYS - 1;
+		const auto hostjoyid = changed_prefs.jports[SelectedPort].id - JSEM_JOYS - num_keys_as_joys;
 		strncpy(tmp, SDL_JoystickNameForIndex(hostjoyid), 255);
 
 		for (auto n = 0; n < 14; ++n)


### PR DESCRIPTION
These are tweaks and fixes to allow a better experience when using retropie using iPAC and more than one joystick/player connected to the ipac keyboard. In short this now allows me to play 2 player amiga emulation on my arcade cabinet without having to plug anything in!
   
Fixes # .

Changes proposed in this pull request:

-It allows 2 retroarch joysticks to be recognised on one keyboard plugged in, if the retroarch config file has 2 players on one keyboard it will automatically create another keyboard which can be selected in "Input"

-Retro arch keyboard as joystick now exits the emulator and opens the menu using hotkeys

-It allows a generic setting which overrides the mouse speed for all games, this can be changed in amiberry.conf using "input_default_mouse_speed=45", the default is 100 as before. This was needed as ALL my mouse games were far too fast using standard retro pie in an arcade cabinet, and a generic setting like this works well.

-When using keyboards as joysticks, the keyboard command also got executed so often this caused issues across varying games when playing 2 players, a new option has been added to amiberry.conf so that these keypresses are ignored if on "input_keyboard_as_joystick_stop_keypresses=1", the default is 0 as before. This is needed because playing 2 player kick off 2, player 2 joystick was mapped as "up" to "r", which meant it kept replaying the game every time the user pressed up!!

@midwan

@HoraceAndTheSpider You can tick this off your list on your projects page too

(I've tested it thoroughly with the iPAC and also when plugging in a PSX controller too, it may need some more testing with other devices!)


