### PR TITLE
Add support for HardKernel ODroid C4 and Khadas VIM3L (AMLSM1 SoCs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,13 @@ else ifneq (,$(findstring AMLG,$(PLATFORM)))
       CPPFLAGS += -DUSE_RENDER_THREAD
     endif
 
+# Amlogic S905D3/S905X3/S905Y3 (AMLSM1) e.g. HardKernel ODroid C4 & Khadas VIM3L (SDL2 64-bit)
+else ifneq (,$(findstring AMLSM1,$(PLATFORM)))
+    CPUFLAGS += -mcpu=cortex-a55
+    CPUFLAGS += -mfloat-abi=hard -mfpu=neon-fp-armv8
+    CPPFLAGS += -DCPU_AARCH64 -D_FILE_OFFSET_BITS=64 -DUSE_RENDER_THREAD
+    AARCH64 = 1
+
 # Odroid Go Advance target (SDL2, 64-bit)
 else ifeq ($(PLATFORM),go-advance)
     CPUFLAGS += -mcpu=cortex-a35


### PR DESCRIPTION
Changes proposed in this pull request:
- Add AMLSM1 platform string in Makefile
- Builds properly against Cortex-A55
- Should work fine on HardKernel Odroid C4 and Khadas VIM3L

@midwan
