### PR TITLE
reduce default_sound_buffer from laggy 16384 to 2048.

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1111,7 +1111,7 @@ struct amiberry_options
 	int default_height = 270;
 	bool default_fullscreen = false;
 	int default_stereo_separation = 7;
-	int default_sound_buffer = 16384;
+	int default_sound_buffer = 2048;
 	int default_joystick_deadzone = 33;
 	bool default_retroarch_quit = true;
 	bool default_retroarch_menu = true;


### PR DESCRIPTION
reduce default_sound_buffer - get rid of laggy sound, works nice on my RPi3!

@midwan
