### PR TITLE
Makefile: fix cross compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ $(error Unknown platform:$(PLATFORM))
 endif
 
 RM     = rm -f
-AS     = as
+AS     ?= as
 CC     ?= gcc
 CXX    ?= g++
 STRIP  ?= strip


### PR DESCRIPTION
Fixes cross compilation. When you build amiberry in a build root that has special build tools for specific targets e.g. https://github.com/SupervisedThinking/LibreELEC-RR/blob/master-rr/packages/supervisedthinking/emulation/standalone/amiberry/package.mk build will fail because host `as` will be used:

```
as: unrecognized option '-mfloat-abi=hard'
make: *** [Makefile:447: src/osdep/neon_helper.o] Error 1
make: *** Waiting for unfinished jobs....
```

Changes proposed in this pull request:
only define AS if AS wasn't already defined so change `AS     = as` to `AS     ?= as` so the toolchain `as` will be used instead of host `as`

@midwan
