### PR TITLE
Split rpi3/rpi4 64-bit builds to fix -mcpu wrong flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,15 +122,28 @@ else ifeq ($(PLATFORM),n2)
     CPPFLAGS += $(CPPFLAGS64) -DUSE_RENDER_THREAD
     AARCH64 = 1
 
-# Raspberry Pi 3/4 (SDL2 64-bit)
-else ifeq ($(PLATFORM),pi64)
+# Raspberry Pi 3 (SDL2 64-bit)
+else ifeq ($(PLATFORM),pi3-64)
+    CPUFLAGS = -mcpu=cortex-a53
+    CPPFLAGS += $(CPPFLAGS64)
+    AARCH64 = 1
+
+# Raspberry Pi 4 (SDL2 64-bit)
+else ifeq ($(PLATFORM),pi4-64)
     CPUFLAGS = -mcpu=cortex-a72+crc+simd+fp
     CPPFLAGS += $(CPPFLAGS64)
     AARCH64 = 1
 
-# Raspberry Pi 3/4 (SDL2 64-bit with DispmanX)
-else ifeq ($(PLATFORM),pi64-dispmanx)
-    CPUFLAGS = -mcpu=cortex-a72
+# Raspberry Pi 3 (SDL2 64-bit with DispmanX)
+else ifeq ($(PLATFORM),pi3-64-dispmanx)
+    CPUFLAGS = -mcpu=cortex-a53
+    CPPFLAGS += $(CPPFLAGS64) $(DISPMANX_FLAGS)
+    LDFLAGS += $(DISPMANX_LDFLAGS)
+    AARCH64 = 1
+
+# Raspberry Pi 4 (SDL2 64-bit with DispmanX)
+else ifeq ($(PLATFORM),pi4-64-dispmanx)
+    CPUFLAGS = -mcpu=cortex-a72+crc+simd+fp
     CPPFLAGS += $(CPPFLAGS64) $(DISPMANX_FLAGS)
     LDFLAGS += $(DISPMANX_LDFLAGS)
     AARCH64 = 1

--- a/Makefile
+++ b/Makefile
@@ -123,26 +123,26 @@ else ifeq ($(PLATFORM),n2)
     AARCH64 = 1
 
 # Raspberry Pi 3 (SDL2 64-bit)
-else ifeq ($(PLATFORM),pi3-64)
+else ifeq ($(PLATFORM),rpi3-64-sdl2)
     CPUFLAGS = -mcpu=cortex-a53
     CPPFLAGS += $(CPPFLAGS64)
     AARCH64 = 1
 
 # Raspberry Pi 4 (SDL2 64-bit)
-else ifeq ($(PLATFORM),pi4-64)
+else ifeq ($(PLATFORM),rpi4-64-sdl2)
     CPUFLAGS = -mcpu=cortex-a72+crc+simd+fp
     CPPFLAGS += $(CPPFLAGS64)
     AARCH64 = 1
 
 # Raspberry Pi 3 (SDL2 64-bit with DispmanX)
-else ifeq ($(PLATFORM),pi3-64-dispmanx)
+else ifeq ($(PLATFORM),rpi3-64-dmx)
     CPUFLAGS = -mcpu=cortex-a53
     CPPFLAGS += $(CPPFLAGS64) $(DISPMANX_FLAGS)
     LDFLAGS += $(DISPMANX_LDFLAGS)
     AARCH64 = 1
 
 # Raspberry Pi 4 (SDL2 64-bit with DispmanX)
-else ifeq ($(PLATFORM),pi4-64-dispmanx)
+else ifeq ($(PLATFORM),rpi4-64-dmx)
     CPUFLAGS = -mcpu=cortex-a72+crc+simd+fp
     CPPFLAGS += $(CPPFLAGS64) $(DISPMANX_FLAGS)
     LDFLAGS += $(DISPMANX_LDFLAGS)


### PR DESCRIPTION
RPI3 uses Cortex-A53 CPU.
RPI4 uses Cortex-A72 CPU.
The -mcpu flag passed in pi64 and dispmanx variants are incorrect for pi3.

Changes proposed in this pull request:
- Split rpi3 and rpi4 64-bit builds

@midwan I think this should be merged before 4.1.5 release.
