### PR TITLE
Makefile changes to make integration to systems like Batocera a bit easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,9 +185,9 @@ else ifeq ($(PLATFORM),go-advance)
     CPPFLAGS += $(CPPFLAGS64)
     AARCH64 = 1
 
-# Generic Cortex A53 aarch64 target (SDL2, 64-bit)
+# Generic aarch64 target defaulting to Cortex A53 CPU (SDL2, 64-bit)
 else ifeq ($(PLATFORM),a64)
-    CPUFLAGS = -mcpu=cortex-a53
+    CPUFLAGS ?= -mcpu=cortex-a53
     CPPFLAGS += $(CPPFLAGS64)
     AARCH64 = 1
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,12 @@ export SDL_LDFLAGS := $(shell $(SDL_CONFIG) --libs)
 
 CPPFLAGS = -MD -MT $@ -MF $(@:%.o=%.d) $(SDL_CFLAGS) -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -DAMIBERRY -D_FILE_OFFSET_BITS=64
 CFLAGS=-pipe -Wno-shift-overflow -Wno-narrowing
-LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lguisan -Lexternal/libguisan/lib -fuse-ld=gold -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -lpthread -lz -lpng -lrt -lFLAC -lmpg123 -ldl -lmpeg2convert -lmpeg2
+USE_LD ?= gold
+LDFLAGS = $(SDL_LDFLAGS) -lSDL2_image -lSDL2_ttf -lguisan -Lexternal/libguisan/lib
+ifneq ($(strip $(USE_LD)),)
+	LDFLAGS += -fuse-ld=$(USE_LD)
+endif
+LDFLAGS += -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -lpthread -lz -lpng -lrt -lFLAC -lmpg123 -ldl -lmpeg2convert -lmpeg2
 
 ifndef DEBUG
 	CFLAGS += -O3


### PR DESCRIPTION
I have two suggestions for making integration of Amiberry to systems like Batocera a bit easier (at least in my humble opinion). Here's the first one changing `Makefile` with two commits.

Changes proposed in this pull request:
- Make `CPUFLAGS` assignment in `a64` platform conditional. This would make it easy to use `a64` as target with CPUFLAGS given to make as needed. First I was making a new `RK3399-64` target for 64-bit RockPro64, but then I thought to suggest this and hear you think about it. The default `CPUFLAGS=-mcpu=cortex-a53` does work with RockPro64 fine. This just adds option for fine tuning if one wants to do it.
- Add new `USE_LD` conditional variable which defaults to `gold` (so by default it should work as before). This is for Batocera integration, but could be usable else where too (haven't checked how Recalbox does it now days): Buildroot used in Batocera build doesn't have `gold` linker and because of that `-fuse-ld=gold` flag is removed with a patch to make the build work. With the new `USE_LD` variable we could just do `USE_LD=""` and would not need the patch.

@midwan
