### PR TITLE
Fix build failure with GCC 11 in floppybridge

### DIFF
--- a/src/floppybridge/floppybridge_abstract.h
+++ b/src/floppybridge/floppybridge_abstract.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <functional>
+#include <cstddef>
 
 #ifdef _WIN32
 #include <tchar.h>


### PR DESCRIPTION
Build fails when using GCC 11 to build Amiberry because NULL is not
in floppybridge_abstract.h. Noticed this when building latest master for
Batocera.

Fixed by including <cstddef> in floppybridge_abstract.h.

See also PR in upstream:
https://github.com/RobSmithDev/FloppyDriveBridge/pull/7

Build error from Batocera for reference:
/rk3399/host/bin/aarch64-buildroot-linux-gnu-g++ -mcpu=cortex-a53 -mabi=lp64 -pipe -Wno-shift-overflow -Wno-narrowing -O3  -std=gnu++14 -MD -MT src/floppybridge/floppybridge_lib.o -MF src/floppybridge/floppybridge_lib.d -I/rk3399/host/aarch64-buildroot-linux-gnu/sysroot/usr/bin/../../usr/include/SDL2 -D_REENTRANT -Iexternal/libguisan/include -Isrc -Isrc/osdep -Isrc/threaddep -Isrc/include -Isrc/archivers -DAMIBERRY -D_FILE_OFFSET_BITS=64 -DCPU_AARCH64  -c -o src/floppybridge/floppybridge_lib.o src/floppybridge/floppybridge_lib.cpp
In file included from src/floppybridge/floppybridge_lib.h:19,
                 from src/floppybridge/floppybridge_lib.cpp:17:
src/floppybridge/floppybridge_abstract.h: In member function ‘virtual const char* FloppyDiskBridge::getLastErrorMessage()’:
src/floppybridge/floppybridge_abstract.h:80:60: error: ‘NULL’ was not declared in this scope
   80 |         virtual const char* getLastErrorMessage() { return NULL; };
      |                                                            ^~~~
In file included from src/floppybridge/floppybridge_lib.h:19,
                 from src/floppybridge/floppybridge_lib.cpp:17:
src/floppybridge/floppybridge_abstract.h:25:1: note: ‘NULL’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
   24 | #include <functional>
  +++ |+#include <cstddef>
   25 |

Changes proposed in this pull request:
- Fix build with GCC 11

Note: I don't have any real drives so I can only test that it builds. Like I said in upstream PR: Including a header shouldn't break anything, but then again, I've heard that many times before sw gets broken :)

@midwan
