### PR TITLE
Fix int overflows in hsync_handler_post()

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -8757,7 +8757,7 @@ static void hsync_handler_post (bool onvsync)
 			if (regs.stopped && currprefs.cpu_idle) {
 				// CPU in STOP state: sleep if enough time left.
 				frame_time_t rpt = read_processor_time ();
-				while (vsync_isdone(NULL) <= 0 && (int)vsyncmintime - (int)(rpt + vsynctimebase / 10) > 0 && (int)vsyncmintime - (int)rpt < vsynctimebase) {
+				while (vsync_isdone(NULL) <= 0 && (int64_t)vsyncmintime - (int64_t)(rpt + vsynctimebase / 10) > 0 && (int64_t)vsyncmintime - (int64_t)rpt < vsynctimebase) {
 					maybe_process_pull_audio();
 //					if (!execute_other_cpu(rpt + vsynctimebase / 10)) {
 						if (cpu_sleep_millis(1) < 0)
@@ -8782,11 +8782,11 @@ static void hsync_handler_post (bool onvsync)
 			linecounter++;
 			events_reset_syncline();
 			if (vsync_isdone(NULL) <= 0 && !currprefs.turbo_emulation) {
-				if ((int)vsyncmaxtime - (int)vsyncmintime > 0) {
-					if ((int)vsyncwaittime - (int)vsyncmintime > 0) {
+				if ((int64_t)vsyncmaxtime - (int64_t)vsyncmintime > 0) {
+					if ((int64_t)vsyncwaittime - (int64_t)vsyncmintime > 0) {
 						frame_time_t rpt = read_processor_time ();
 						/* Extra time left? Do some extra CPU emulation */
-						if ((int)vsyncmintime - (int)rpt > 0) {
+						if ((int64_t)vsyncmintime - (int64_t)rpt > 0) {
 							if (regs.stopped && currprefs.cpu_idle && sleeps_remaining > 0) {
 								// STOP STATE: sleep.
 								cpu_sleep_millis(1);
@@ -8822,7 +8822,7 @@ static void hsync_handler_post (bool onvsync)
 		if (audio_is_pull() > 0 && !currprefs.turbo_emulation) {
 			maybe_process_pull_audio();
 			frame_time_t rpt = read_processor_time();
-			while (audio_pull_buffer() > 1 && (!isvsync() || (vsync_isdone(NULL) <= 0 && (int)vsyncmintime - (int)(rpt + vsynctimebase / 10) > 0 && (int)vsyncmintime - (int)rpt < vsynctimebase))) {
+			while (audio_pull_buffer() > 1 && (!isvsync() || (vsync_isdone(NULL) <= 0 && (int64_t)vsyncmintime - (int64_t)(rpt + vsynctimebase / 10) > 0 && (int64_t)vsyncmintime - (int64_t)rpt < vsynctimebase))) {
 				cpu_sleep_millis(1);
 				maybe_process_pull_audio();
 				rpt = read_processor_time();
@@ -8834,7 +8834,7 @@ static void hsync_handler_post (bool onvsync)
 			if (vsync_isdone(NULL) <= 0 && !currprefs.turbo_emulation) {
 				frame_time_t rpt = read_processor_time();
 				// sleep if more than 2ms "free" time
-				while (vsync_isdone(NULL) <= 0 && (int)vsyncmintime - (int)(rpt + vsynctimebase / 10) > 0 && (int)vsyncmintime - (int)rpt < vsynctimebase) {
+				while (vsync_isdone(NULL) <= 0 && (int64_t)vsyncmintime - (int64_t)(rpt + vsynctimebase / 10) > 0 && (int64_t)vsyncmintime - (int64_t)rpt < vsynctimebase) {
 					maybe_process_pull_audio();
 //					if (!execute_other_cpu(rpt + vsynctimebase / 10)) {
 						if (cpu_sleep_millis(1) < 0)


### PR DESCRIPTION
vsyncmintime and rpt (and read_processor_time()) types are of type
frame_time_t, which is typedef unsigned long frame_time_t. The default
data model on aarch64-gcc seems to be LP64 (at least on Batocera /
Buildroot) which makes int 32-bits and long 64-bits. This causes (int)
casts in hsync_handler_post() calculations to overflow.

For me, this caused Amiberry to freeze occasionally on Batocera, but not
on Manjaro ARM. I guess this is because Batocera being lighter gives
Amiberry more runtime making it possible to sleep in
hsync_handler_post() loops and getting stuck for a while in those.
(Based on sleep if more than 2ms "free" time comment in the code.)

As read_processor_time() measures microseconds these overflows happen
every 2 ^ 32 microseconds (about 1 h 11 min 35 s). clock_gettime()'s
CLOCK_MONOTONIC values in read_processor_time() seem to be "since system
start-up time" (at least my case) so the time of the first freeze
depends on when amiberry is started.

Fixed by casting calculations in hsync_handler_post to int64_t.

Changes proposed in this pull request:
- change (int) casts of vsyncmintime and rpt to (int64_t) casts to prevent overflow

@midwan
