### PR TITLE
Ported to OS X for M1 based Macs

### DIFF
--- a/external/libguisan/Makefile
+++ b/external/libguisan/Makefile
@@ -1,5 +1,5 @@
 TARGET  = lib/libguisan.a
-DYLIB_TARGET = lib/libguisan.dylib
+DYLIB_TARGET = dylib/libguisan.dylib
   
 AR      = ar
 

--- a/external/libguisan/Makefile
+++ b/external/libguisan/Makefile
@@ -1,4 +1,5 @@
 TARGET  = lib/libguisan.a
+DYLIB_TARGET = lib/libguisan.dylib
   
 AR      = ar
 
@@ -7,18 +8,29 @@ SOURCE	= $(foreach dir,$(DIRS),$(wildcard $(dir)/*.cpp))
 OBJS    = $(patsubst %.c,%.o,$(patsubst %.cpp,%.o,$(SOURCE)))
 DEPS	= $(SOURCE:%.cpp=%.d)
 
+ifeq ($(PLATFORM),osx)
+	# Create DYLIB on OS X
+        LDFLAGS += -lsdl2 -no_branch_islands
+        DYLIB=$(CXX) -dynamiclib  -std=c++14 -headerpad_max_install_names -current_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -o $(DYLIB_TARGET) $(OBJS)
+        CXX=/usr/bin/c++
+else
+        DYLIB=
+endif
+
 CPPFLAGS +=-I./include $(SDL_CFLAGS) -MD -MT $@ -MF $(@:%.o=%.d)
   
 .PHONY : all clean
   
 $(TARGET) : $(OBJS)
 	$(AR) cr $(TARGET) $(OBJS)
+	$(DYLIB)
 
 all : $(TARGET)
 
 clean :
 	rm -f $(OBJS) $(DEPS)
 	rm -f $(TARGET)
+	rm -f lib/libguisan.dylib
 
 cleanprofile:
 	rm -f $(OBJS:%.o=%.gcda)

--- a/external/libguisan/Makefile
+++ b/external/libguisan/Makefile
@@ -11,7 +11,7 @@ DEPS	= $(SOURCE:%.cpp=%.d)
 ifeq ($(PLATFORM),osx)
 	# Create DYLIB on OS X
         LDFLAGS += -lsdl2 -no_branch_islands
-        DYLIB=$(CXX) -dynamiclib  -std=c++14 -headerpad_max_install_names -current_version 1.0 -fvisibility=hidden -undefined dynamic_lookup -o $(DYLIB_TARGET) $(OBJS)
+        DYLIB=$(CXX) -dynamiclib  -std=c++14 -install_name libguisan.dylib -fvisibility=hidden -undefined dynamic_lookup -o $(DYLIB_TARGET) $(OBJS)
         CXX=/usr/bin/c++
 else
         DYLIB=

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+USERDIR=`echo ~`
+
+LONGVER=`cat src/osdep/target.h | grep AMIBERRYVERSION | awk -F '_T\\\(\\\"' '{print $2}' | awk -F '\\\"' '{printf $1}'`
+VERSION=`echo $LONGVER | awk -F v '{printf $2}' | awk '{print $1}'`
+MAJOR=`echo $VERSION | awk -F . '{printf $1}'`
+MINOR=`echo $VERSION | awk -F . '{printf $2}'`
+
+
+cat Info.plist.template | sed -e "s/LONGVERSION/$LONGVER/" | sed -e "s/VERSION/$VERSION/" | sed -e "s/MAJOR/$MAJOR/" | sed -e "s/MINOR/$MINOR/" >Info.plist
+echo "Removing old App directory"
+rm -Rf Amiberry.app
+echo "Creating App directory"
+# Make directory for App bundle
+mkdir -p Amiberry.app/Contents/MacOS
+mkdir -p Amiberry.app/Contents/Frameworks
+mkdir -p Amiberry.app/Contents/Resources
+# Copy executable into App bundle
+cp amiberry Amiberry.app/Contents/MacOS/Amiberry
+# Copy parameter list into the bundle
+cp Info.plist Amiberry.app/Contents/Info.plist
+# Self-sign binary
+export CODE_SIGN_ENTITLEMENTS=Entitlements.plist
+codesign --entitlements=Entitlements.plist --force -s - Amiberry.app
+# Copy Guisan library into the bundle
+cp external/libguisan/dylib/libguisan.dylib Amiberry.app/Contents/MacOS
+# Install libguisan lib into app bundle
+# Copy docs into the bundle
+cp -R docs Amiberry.app/Contents/Resources
+# Copy data into the bundle
+cp -R data Amiberry.app/Contents/Resources
+# Copy kickstarts into the bundle
+cp -R kickstarts Amiberry.app/Contents/Resources
+# Overwrite default conf with OSX specific one
+mkdir Amiberry.app/Contents/resources/conf
+cat conf/amiberry-osx.conf | sed -e "s#USERDIR#$USERDIR#g" >Amiberry.app/Contents/Resources/conf/amiberry.conf
+
+# Create application directories
+mkdir -p ~/Documents/Amiberry/Hard\ Drives ~/Documents/Amiberry/Configurations ~/Documents/Amiberry/Controllers ~/Documents/Amibery/Logfiles ~Documents/Amiberry/Kickstarts ~Documents/Amiberry/RP9 ~/Documents/Amiberry/Data/Floppy_Sounds ~/Documents/Amiberry/Savestates ~/Documents/Amiberry/Screenshots ~/Documents/Amiberry/Docs
+
+# Copy files to their destination
+cp -a conf/* ~/Documents/Amiberry/Configurations
+cp -a controllers/* ~/Documents/Amiberry/Controllers
+cp -a kickstarts/* ~/Documents/Amiberry/Kickstarts
+cp -a data/* ~/Documents/Amiberry/Data
+cp -a docs/* ~/Documents/Amiberry/Docs

--- a/src/fsusage.cpp
+++ b/src/fsusage.cpp
@@ -23,6 +23,9 @@ Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  */
 
 #if defined(STAT_STATVFS) && !defined(__ANDROID__)
 #include <sys/statvfs.h>
+// For osx, sigurbjornl
+#elif defined (__MACH__)
+#include <sys/mount.h>
 #else
 #include <sys/vfs.h>
 #endif
@@ -100,7 +103,7 @@ int get_fs_usage (const TCHAR *path, const TCHAR *disk, struct fs_usage *fsp)
 # include <sys/mount.h>
 #endif
 
-#if HAVE_SYS_VFS_H
+#if HAVE_SYS_VFS_H and !defined(__MACH__)
 # include <sys/vfs.h>
 #endif
 
@@ -116,7 +119,7 @@ int get_fs_usage (const TCHAR *path, const TCHAR *disk, struct fs_usage *fsp)
 # include <fcntl.h>
 #endif
 
-#if HAVE_SYS_STATFS_H
+#if HAVE_SYS_STATFS_H and !defined(__MACH__)
 # include <sys/statfs.h>
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,9 @@
 #endif
 
 #include <iostream>
+#ifndef __MACH__
 #include <linux/kd.h>
+#endif
 #include <sys/ioctl.h>
 #include "keyboard.h"
 

--- a/src/osdep/aarch64_helper_osx.s
+++ b/src/osdep/aarch64_helper_osx.s
@@ -1,0 +1,1154 @@
+// Some functions and tests to increase performance in drawing.cpp and custom.cpp
+.section        __TEXT,__text,regular,pure_instructions
+
+//.arm
+
+// this is a hack to have a _symbol defined for the assembly routines here so that the linker correctly links them with the C code
+// it creates an unneccesary symbol on other systems, there's a probably a workaround for this
+
+.global _save_host_fp_regs
+.global _restore_host_fp_regs
+.global _copy_screen_8bit_to_16bit
+.global _copy_screen_8bit_to_32bit
+.global _copy_screen_16bit_swap
+.global _copy_screen_16bit_to_32bit
+.global _copy_screen_32bit_to_16bit
+.global _copy_screen_32bit_to_32bit
+.global _ARM_doline_n1
+.global _NEON_doline_n2
+.global _NEON_doline_n3
+.global _NEON_doline_n4
+.global _NEON_doline_n5
+.global _NEON_doline_n6
+.global _NEON_doline_n7
+.global _NEON_doline_n8
+
+.text
+
+.align 8
+
+//----------------------------------------------------------------
+// save_host_fp_regs
+//----------------------------------------------------------------
+_save_host_fp_regs:
+  st4  {v7.2D-v10.2D}, [x0], #64
+  st4  {v11.2D-v14.2D}, [x0], #64
+  st1  {v15.2D}, [x0], #16
+  ret
+  
+//----------------------------------------------------------------
+// restore_host_fp_regs
+//----------------------------------------------------------------
+_restore_host_fp_regs:
+  ld4  {v7.2D-v10.2D}, [x0], #64
+  ld4  {v11.2D-v14.2D}, [x0], #64
+  ld1  {v15.2D}, [x0], #16
+  ret
+
+
+//----------------------------------------------------------------
+// copy_screen_8bit_to_16bit
+//
+// x0: uae_u8   *dst
+// x1: uae_u8   *src
+// x2: int      bytes always a multiple of 64: even number of lines, number of pixel per line is multiple of 32 (320, 640, 800, 1024, 1152, 1280)
+// x3: uae_u32  *clut
+//
+// void copy_screen_8bit_to_16bit(uae_u8 *dst, uae_u8 *src, int bytes, uae_u32 *clut);
+//
+//----------------------------------------------------------------
+_copy_screen_8bit_to_16bit:
+  // Function continues
+  mov       x7, #64
+copy_screen_8bit_loop:
+  ldrsw     x4, [x1], #4
+  ubfx      x5, x4, #0, #8
+  ldrsw     x6, [x3, x5, lsl #2]
+  ubfx      x5, x4, #8, #8
+  strh      w6, [x0], #2
+  ldrsw     x6, [x3, x5, lsl #2]
+  ubfx      x5, x4, #16, #8
+  strh      w6, [x0], #2
+  ldrsw     x6, [x3, x5, lsl #2]
+  ubfx      x5, x4, #24, #8
+  strh      w6, [x0], #2
+  ldrsw     x6, [x3, x5, lsl #2]
+  subs      x7, x7, #4
+  strh      w6, [x0], #2
+  bgt       copy_screen_8bit_loop
+  subs      x2, x2, #64
+  bgt       _copy_screen_8bit_to_16bit
+  ret
+  
+
+//----------------------------------------------------------------
+// copy_screen_8bit_to_32bit
+//
+// r0: uae_u8   *dst
+// r1: uae_u8   *src
+// r2: int      bytes always a multiple of 64: even number of lines, number of pixel per line is multiple of 32 (320, 640, 800, 1024, 1152, 1280)
+// r3: uae_u32  *clut
+//
+// void copy_screen_8bit_to_32bit(uae_u8 *dst, uae_u8 *src, int bytes, uae_u32 *clut);
+//
+//----------------------------------------------------------------
+_copy_screen_8bit_to_32bit:
+  // Function continues
+  ldrsw     x4, [x1], #4
+  subs      x2, x2, #4
+  ubfx      x5, x4, #0, #8
+  ldrsw     x6, [x3, x5, lsl #2]
+  ubfx      x5, x4, #8, #8
+  str       w6, [x0], #4
+  ldrsw     x6, [x3, x5, lsl #2]
+  ubfx      x5, x4, #16, #8
+  str       w6, [x0], #4
+  ldrsw     x6, [x3, x5, lsl #2]
+  ubfx      x5, x4, #24, #8
+  str       w6, [x0], #4
+  ldrsw     x6, [x3, x5, lsl #2]
+  str       w6, [x0], #4
+  bgt       _copy_screen_8bit_to_32bit
+  ret
+
+
+//----------------------------------------------------------------
+// copy_screen_16bit_swap
+//
+// x0: uae_u8   *dst
+// x1: uae_u8   *src
+// x2: int      bytes always a multiple of 128: even number of lines, 2 bytes per pixel, number of pixel per line is multiple of 32 (320, 640, 800, 1024, 1152, 1280)
+//
+// void copy_screen_16bit_swap(uae_u8 *dst, uae_u8 *src, int bytes);
+//
+//----------------------------------------------------------------
+_copy_screen_16bit_swap:
+  // Function continues
+  ld4       {v0.2D-v3.2D}, [x1], #64
+  rev16     v0.16b, v0.16b
+  rev16     v1.16b, v1.16b
+  rev16     v2.16b, v2.16b
+  rev16     v3.16b, v3.16b
+  subs      w2, w2, #64
+  st4       {v0.2D-v3.2D}, [x0], #64
+  bne 	    _copy_screen_16bit_swap
+  ret
+  
+
+//----------------------------------------------------------------
+// copy_screen_16bit_to_32bit
+//
+// r0: uae_u8   *dst - Format (bytes): in memory argb
+// r1: uae_u8   *src - Format (bits): gggb bbbb rrrr rggg
+// r2: int      bytes always a multiple of 128: even number of lines, 2 bytes per pixel, number of pixel per line is multiple of 32 (320, 640, 800, 1024, 1152, 1280)
+//
+// void copy_screen_16bit_to_32bit(uae_u8 *dst, uae_u8 *src, int bytes);
+//
+//----------------------------------------------------------------
+_copy_screen_16bit_to_32bit:
+  // Function continues
+  ldrh      w3, [x1], #2
+  subs      w2, w2, #2
+  rev16     w3, w3
+  ubfx      w4, w3, #0, #5
+  lsl       w4, w4, #3
+  lsr       w3, w3, #5
+  bfi       w4, w3, #10, #6
+  lsr       w3, w3, #6
+  bfi       w4, w3, #19, #5
+  str       w4, [x0], #4
+  bne       _copy_screen_16bit_to_32bit
+  ret
+
+
+//----------------------------------------------------------------
+// copy_screen_32bit_to_16bit
+//
+// x0: uae_u8   *dst - Format (bits): rrrr rggg gggb bbbb
+// x1: uae_u8   *src - Format (bytes) in memory bgra
+// x2: int      bytes
+//
+// void copy_screen_32bit_to_16bit(uae_u8 *dst, uae_u8 *src, int bytes);
+//
+//----------------------------------------------------------------
+
+_copy_screen_32bit_to_16bit:
+  //  MacOS X does not like this
+  // ldr       x3, =Masks_rgb
+  // But does like these two
+  adrp      x3,Masks_rgb@PAGE
+  add       x3,x3,Masks_rgb@PAGEOFF
+  //  End of fix for MacOSX, sigurbjornl
+  ld2r      {v0.4S-v1.4S}, [x3]
+copy_screen_32bit_to_16bit_loop:
+  ld1       {v3.4S}, [x1], #16
+  rev32     v3.16B, v3.16B
+  ushr      v4.4S, v3.4S, #8
+  ushr      v5.4S, v3.4S, #5
+  ushr      v3.4S, v3.4S, #3
+  bit       v3.16B, v4.16B, v0.16B
+  bit       v3.16B, v5.16B, v1.16B
+  xtn       v3.4H, v3.4S
+  subs      w2, w2, #16
+  st1       {v3.4H}, [x0], #8
+  bne       copy_screen_32bit_to_16bit_loop
+  ret
+
+
+//----------------------------------------------------------------
+// copy_screen_32bit_to_32bit
+//
+// r0: uae_u8   *dst - Format (bytes): in memory argb
+// r1: uae_u8   *src - Format (bytes): in memory bgra
+// r2: int      bytes
+//
+// void copy_screen_32bit_to_32bit(uae_u8 *dst, uae_u8 *src, int bytes);
+//
+//----------------------------------------------------------------
+_copy_screen_32bit_to_32bit:
+  // Function continues
+  ld1       {v3.4S}, [x1], #16
+  subs      w2, w2, #16
+  rev32     v3.16B, v3.16B
+  st1       {v3.4S}, [x0], #16
+  bne       _copy_screen_32bit_to_32bit
+  ret
+
+
+//----------------------------------------------------------------
+// ARM_doline_n1
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void ARM_doline_n1(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_ARM_doline_n1:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS x does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x3, x3, x2           // real_bplpt[0]
+
+# Mac OS x does not like this
+#  ldr       x10, =Lookup_doline_n1
+# But does like this
+# End of fix for MacOSX, sigurbjornl
+  adrp 	    x10,Lookup_doline_n1@PAGE
+  add       x10,x10,Lookup_doline_n1@PAGEOFF
+
+ 
+ARM_doline_n1_loop:
+  ldr       w2, [x3], #4
+
+  ubfx      x5, x2, #28, #4
+  ldr       w6, [x10, x5, lsl #2]
+  
+  ubfx      x5, x2, #24, #4
+  ldr       w7, [x10, x5, lsl #2]
+
+  ubfx      x5, x2, #20, #4
+  ldr       w8, [x10, x5, lsl #2]
+
+  ubfx      x5, x2, #16, #4
+  ldr       w9, [x10, x5, lsl #2]
+  stp       w6, w7, [x0], #8     
+  stp       w8, w9, [x0], #8     
+  
+  ubfx      x5, x2, #12, #4
+  ldr       w6, [x10, x5, lsl #2]
+
+  ubfx      x5, x2, #8, #4
+  ldr       w7, [x10, x5, lsl #2]
+
+  ubfx      x5, x2, #4, #4
+  ldr       w8, [x10, x5, lsl #2]
+
+  ubfx      x5, x2, #0, #4
+  ldr       w9, [x10, x5, lsl #2]
+  stp       w6, w7, [x0], #8     
+  stp       w8, w9, [x0], #8     
+
+  subs      x1, x1, #1
+  bgt       ARM_doline_n1_loop
+  
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n2
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n2(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n2:
+
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  
+// Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.16b, #0x03
+  movi      v18.8b, #1
+  
+NEON_doline_n2_loop:
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  
+  ushr      v2.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v3.8b, v1.8b, v18.8b  // tmpa = a << shift
+  bit       v1.8b, v2.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v3.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  zip2      v4.8b, v1.8b, v0.8b
+  zip1      v5.8b, v1.8b, v0.8b
+
+  zip1      v5.2d, v4.2d, v5.2d
+  
+  ushr      v0.16b, v5.16b, #6
+  ushr      v1.16b, v5.16b, #4
+  ushr      v2.16b, v5.16b, #2
+
+  and       v1.16b, v1.16b, v17.16b
+  and       v2.16b, v2.16b, v17.16b
+  and       v5.16b, v5.16b, v17.16b
+
+  zip2      v21.8h, v0.8h, v1.8h
+  zip1      v23.8h, v0.8h, v1.8h
+
+  zip2      v20.8h, v2.8h, v5.8h
+  zip1      v22.8h, v2.8h, v5.8h
+
+  zip2      v1.4s, v21.4s, v20.4s
+  zip1      v3.4s, v21.4s, v20.4s
+
+  uzp2      v0.2d, v1.2d, v1.2d
+  uzp2      v2.2d, v3.2d, v3.2d
+
+  st4       { v0.d, v1.d, v2.d, v3.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n2_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v23.4s, v22.4s
+  zip1      v7.4s, v23.4s, v22.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n2_loop
+  
+NEON_doline_n2_exit:
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n3
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n3(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n3:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X Does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  add       x4, x3, #200
+
+  // Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.8b, #0x33
+  movi      v18.16b, #0x0f
+
+NEON_doline_n3_loop:
+  movi      v19.8b, #1
+
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  ld1       {v2.8b}, [x4], #8
+  movi      v3.8b, #0
+
+  ushr      v4.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v5.8b, v1.8b, v19.8b  // tmpa = a << shift
+  bit       v1.8b, v4.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v5.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v4.8b, v2.8b, #1      // tmpb = b >> shift
+  bif       v2.8b, v3.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+  bit       v3.8b, v4.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 2
+      
+  ushr      v4.8b, v0.8b, #2      // tmpb = b >> shift
+  ushl      v5.8b, v2.8b, v19.8b  // tmpa = a << shift
+  bit       v2.8b, v4.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v5.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v4.8b, v1.8b, #2      // tmpb = b >> shift
+  ushl      v5.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v4.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v1.8b, v5.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  zip2      v4.8b, v3.8b, v2.8b
+  zip1      v5.8b, v3.8b, v2.8b
+  zip2      v6.8b, v1.8b, v0.8b
+  zip1      v7.8b, v1.8b, v0.8b
+
+  zip1      v20.8h, v4.8h, v6.8h
+  zip1      v21.8h, v5.8h, v7.8h
+
+  ushr      v0.16b, v20.16b, #4
+  ushr      v1.16b, v21.16b, #4
+
+  and       v20.16b, v20.16b, v18.16b
+  and       v21.16b, v21.16b, v18.16b
+
+  zip2      v5.4s, v1.4s, v21.4s
+  zip1      v7.4s, v1.4s, v21.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n3_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v0.4s, v20.4s
+  zip1      v7.4s, v0.4s, v20.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n3_loop
+
+NEON_doline_n3_exit:
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n4
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n4(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n4:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X Does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  add       x4, x3, #200
+  add       x5, x4, #200
+
+  // Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.8b, #0x33
+  movi      v18.16b, #0x0f
+
+NEON_doline_n4_loop:
+  movi      v19.8b, #1
+
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  ld1       {v2.8b}, [x4], #8
+  ld1       {v3.8b}, [x5], #8
+
+  ushr      v4.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v5.8b, v1.8b, v19.8b  // tmpa = a << shift
+  bit       v1.8b, v4.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v5.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v4.8b, v2.8b, #1      // tmpb = b >> shift
+  ushl      v5.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v4.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v2.8b, v5.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 2
+      
+  ushr      v4.8b, v0.8b, #2      // tmpb = b >> shift
+  ushl      v5.8b, v2.8b, v19.8b  // tmpa = a << shift
+  bit       v2.8b, v4.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v5.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v4.8b, v1.8b, #2      // tmpb = b >> shift
+  ushl      v5.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v4.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v1.8b, v5.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  zip2      v4.8b, v3.8b, v2.8b
+  zip1      v5.8b, v3.8b, v2.8b
+  zip2      v6.8b, v1.8b, v0.8b
+  zip1      v7.8b, v1.8b, v0.8b
+
+  zip1      v20.8h, v4.8h, v6.8h
+  zip1      v21.8h, v5.8h, v7.8h
+
+  ushr      v0.16b, v20.16b, #4
+  ushr      v1.16b, v21.16b, #4
+
+  and       v20.16b, v20.16b, v18.16b
+  and       v21.16b, v21.16b, v18.16b
+
+  zip2      v5.4s, v1.4s, v21.4s
+  zip1      v7.4s, v1.4s, v21.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n4_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v0.4s, v20.4s
+  zip1      v7.4s, v0.4s, v20.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n4_loop
+
+NEON_doline_n4_exit:
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n5
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n5(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n5:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X Does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  add       x4, x3, #200
+  add       x5, x4, #200
+  add       x6, x5, #200
+
+  // Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.8b, #0x33
+  movi      v18.16b, #0x0f
+
+NEON_doline_n5_loop:
+  movi      v19.8b, #1
+
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  ld1       {v2.8b}, [x4], #8
+  ld1       {v3.8b}, [x5], #8
+  ld1       {v4.8b}, [x6], #8
+  movi      v5.8b, #0
+  movi      v6.8b, #0
+  movi      v7.8b, #0
+
+  ushr      v20.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v1.8b, v19.8b  // tmpa = a << shift
+  bit       v1.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v2.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v2.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #1      // tmpb = b >> shift
+  bif       v4.8b, v5.8b, v16.8b   // b = b and bit set from tmpa if mask (0x55) is false
+  bit       v5.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 2
+
+  ushr      v20.8b, v0.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v2.8b, v19.8b  // tmpa = a << shift
+  bit       v2.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v1.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v1.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #2      // tmpb = b >> shift
+  bif       v4.8b, v6.8b, v17.8b   // b = b and bit set from tmpa if mask (0x55) is false
+  bit       v6.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  ushr      v20.8b, v5.8b, #2      // tmpb = b >> shift
+  bif       v5.8b, v7.8b, v17.8b   // b = b and bit set from tmpa if mask (0x55) is false
+  bit       v7.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 4
+
+  ushr      v20.8b, v3.8b, #4
+  ushl      v21.8b, v7.8b, v19.8b
+  bit       v7.8b, v20.8b, v18.8b
+  bif       v3.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v2.8b, #4
+  ushl      v21.8b, v6.8b, v19.8b
+  bit       v6.8b, v20.8b, v18.8b
+  bif       v2.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v1.8b, #4
+  ushl      v21.8b, v5.8b, v19.8b
+  bit       v5.8b, v20.8b, v18.8b
+  bif       v1.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v0.8b, #4
+  ushl      v21.8b, v4.8b, v19.8b
+  bit       v4.8b, v20.8b, v18.8b
+  bif       v0.8b, v21.8b, v18.8b
+
+  zip1      v20.16b, v7.16b, v6.16b
+  zip1      v21.16b, v5.16b, v4.16b
+  zip1      v22.16b, v3.16b, v2.16b
+  zip1      v23.16b, v1.16b, v0.16b
+
+  zip2      v0.8h, v20.8h, v21.8h
+  zip1      v1.8h, v20.8h, v21.8h
+  zip2      v2.8h, v22.8h, v23.8h
+  zip1      v3.8h, v22.8h, v23.8h
+
+  zip2      v5.4s, v1.4s, v3.4s
+  zip1      v7.4s, v1.4s, v3.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n5_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v0.4s, v2.4s
+  zip1      v7.4s, v0.4s, v2.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n5_loop
+
+NEON_doline_n5_exit:
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n6
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n6(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n6:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X Does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  add       x4, x3, #200
+  add       x5, x4, #200
+  add       x6, x5, #200
+  add       x7, x6, #200
+
+  // Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.8b, #0x33
+  movi      v18.16b, #0x0f
+
+NEON_doline_n6_loop:
+  movi      v19.8b, #1
+
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  ld1       {v2.8b}, [x4], #8
+  ld1       {v3.8b}, [x5], #8
+  ld1       {v4.8b}, [x6], #8
+  ld1       {v5.8b}, [x7], #8
+  movi      v6.8b, #0
+  movi      v7.8b, #0
+
+  ushr      v20.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v1.8b, v19.8b  // tmpa = a << shift
+  bit       v1.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v2.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v2.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v5.8b, v19.8b  // tmpa = a << shift
+  bit       v5.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v4.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 2
+
+  ushr      v20.8b, v0.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v2.8b, v19.8b  // tmpa = a << shift
+  bit       v2.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v1.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v1.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #2      // tmpb = b >> shift
+  bif       v4.8b, v6.8b, v17.8b   // b = b and bit set from tmpa if mask (0x55) is false
+  bit       v6.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  ushr      v20.8b, v5.8b, #2      // tmpb = b >> shift
+  bif       v5.8b, v7.8b, v17.8b   // b = b and bit set from tmpa if mask (0x55) is false
+  bit       v7.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 4
+
+  ushr      v20.8b, v3.8b, #4
+  ushl      v21.8b, v7.8b, v19.8b
+  bit       v7.8b, v20.8b, v18.8b
+  bif       v3.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v2.8b, #4
+  ushl      v21.8b, v6.8b, v19.8b
+  bit       v6.8b, v20.8b, v18.8b
+  bif       v2.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v1.8b, #4
+  ushl      v21.8b, v5.8b, v19.8b
+  bit       v5.8b, v20.8b, v18.8b
+  bif       v1.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v0.8b, #4
+  ushl      v21.8b, v4.8b, v19.8b
+  bit       v4.8b, v20.8b, v18.8b
+  bif       v0.8b, v21.8b, v18.8b
+
+  zip1      v20.16b, v7.16b, v6.16b
+  zip1      v21.16b, v5.16b, v4.16b
+  zip1      v22.16b, v3.16b, v2.16b
+  zip1      v23.16b, v1.16b, v0.16b
+
+  zip2      v0.8h, v20.8h, v21.8h
+  zip1      v1.8h, v20.8h, v21.8h
+  zip2      v2.8h, v22.8h, v23.8h
+  zip1      v3.8h, v22.8h, v23.8h
+
+  zip2      v5.4s, v1.4s, v3.4s
+  zip1      v7.4s, v1.4s, v3.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n6_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v0.4s, v2.4s
+  zip1      v7.4s, v0.4s, v2.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n6_loop
+
+NEON_doline_n6_exit:
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n7
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n7(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n7:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X Does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  add       x4, x3, #200
+  add       x5, x4, #200
+  add       x6, x5, #200
+  add       x7, x6, #200
+  add       x8, x7, #200
+
+  // Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.8b, #0x33
+  movi      v18.16b, #0x0f
+
+NEON_doline_n7_loop:
+  movi      v19.8b, #1
+
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  ld1       {v2.8b}, [x4], #8
+  ld1       {v3.8b}, [x5], #8
+  ld1       {v4.8b}, [x6], #8
+  ld1       {v5.8b}, [x7], #8
+  ld1       {v6.8b}, [x8], #8
+  movi      v7.8b, #0
+
+  ushr      v20.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v1.8b, v19.8b  // tmpa = a << shift
+  bit       v1.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v2.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v2.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v5.8b, v19.8b  // tmpa = a << shift
+  bit       v5.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v4.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v6.8b, #1      // tmpb = b >> shift
+  bif       v6.8b, v7.8b, v16.8b   // b = b anh bit set from tmpa if mask (0x55) is false
+  bit       v7.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 2
+
+  ushr      v20.8b, v0.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v2.8b, v19.8b  // tmpa = a << shift
+  bit       v2.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v1.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v1.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v6.8b, v19.8b  // tmpa = a << shift
+  bit       v6.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v4.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v5.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v7.8b, v19.8b  // tmpa = a << shift
+  bit       v7.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v5.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 4
+
+  ushr      v20.8b, v3.8b, #4
+  ushl      v21.8b, v7.8b, v19.8b
+  bit       v7.8b, v20.8b, v18.8b
+  bif       v3.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v2.8b, #4
+  ushl      v21.8b, v6.8b, v19.8b
+  bit       v6.8b, v20.8b, v18.8b
+  bif       v2.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v1.8b, #4
+  ushl      v21.8b, v5.8b, v19.8b
+  bit       v5.8b, v20.8b, v18.8b
+  bif       v1.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v0.8b, #4
+  ushl      v21.8b, v4.8b, v19.8b
+  bit       v4.8b, v20.8b, v18.8b
+  bif       v0.8b, v21.8b, v18.8b
+
+  zip1      v20.16b, v7.16b, v6.16b
+  zip1      v21.16b, v5.16b, v4.16b
+  zip1      v22.16b, v3.16b, v2.16b
+  zip1      v23.16b, v1.16b, v0.16b
+
+  zip2      v0.8h, v20.8h, v21.8h
+  zip1      v1.8h, v20.8h, v21.8h
+  zip2      v2.8h, v22.8h, v23.8h
+  zip1      v3.8h, v22.8h, v23.8h
+
+  zip2      v5.4s, v1.4s, v3.4s
+  zip1      v7.4s, v1.4s, v3.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n7_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v0.4s, v2.4s
+  zip1      v7.4s, v0.4s, v2.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n7_loop
+
+NEON_doline_n7_exit:
+  ret
+
+
+.align 8
+
+//----------------------------------------------------------------
+// NEON_doline_n8
+//
+// x0: uae_u32   *pixels
+// x1: int       wordcount
+// x2: int       lineno 
+//
+// void NEON_doline_n8(uae_u32 *pixels, int wordcount, int lineno);
+//
+//----------------------------------------------------------------
+_NEON_doline_n8:
+  mov       x3, #1600
+  mul       x2, x2, x3
+# Mac OS X Does not like this
+#  ldr       x3, =line_data
+# But does like this
+  adrp	    x3,_line_data@PAGE
+  add	    x3,x3,_line_data@PAGEOFF
+# End of fix for Mac OS X, sigurbjornl
+  add       x2, x3, x2           // real_bplpt[0]
+  add       x3, x2, #200
+  add       x4, x3, #200
+  add       x5, x4, #200
+  add       x6, x5, #200
+  add       x7, x6, #200
+  add       x8, x7, #200
+  add       x9, x8, #200
+
+  // Load masks to registers
+  movi      v16.8b, #0x55
+  movi      v17.8b, #0x33
+  movi      v18.16b, #0x0f
+
+NEON_doline_n8_loop:
+  movi      v19.8b, #1
+
+  ld1       {v0.8b}, [x2], #8
+  ld1       {v1.8b}, [x3], #8
+  ld1       {v2.8b}, [x4], #8
+  ld1       {v3.8b}, [x5], #8
+  ld1       {v4.8b}, [x6], #8
+  ld1       {v5.8b}, [x7], #8
+  ld1       {v6.8b}, [x8], #8
+  ld1       {v7.8b}, [x9], #8
+
+  ushr      v20.8b, v0.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v1.8b, v19.8b  // tmpa = a << shift
+  bit       v1.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v2.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v2.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v5.8b, v19.8b  // tmpa = a << shift
+  bit       v5.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v4.8b, v21.8b, v16.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v6.8b, #1      // tmpb = b >> shift
+  ushl      v21.8b, v7.8b, v19.8b  // tmpa = a << shift
+  bit       v7.8b, v20.8b, v16.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v6.8b, v21.8b, v16.8b  // b = b anh bit set from tmpa if mask (0x55) is false
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 2
+
+  ushr      v20.8b, v0.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v2.8b, v19.8b  // tmpa = a << shift
+  bit       v2.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v0.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v1.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v3.8b, v19.8b  // tmpa = a << shift
+  bit       v3.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v1.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v4.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v6.8b, v19.8b  // tmpa = a << shift
+  bit       v6.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v4.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  ushr      v20.8b, v5.8b, #2      // tmpb = b >> shift
+  ushl      v21.8b, v7.8b, v19.8b  // tmpa = a << shift
+  bit       v7.8b, v20.8b, v17.8b  // a = a and bit set from tmpb if mask (0x55) is true 
+  bif       v5.8b, v21.8b, v17.8b  // b = b and bit set from tmpa if mask (0x55) is false
+
+  add       v19.8b, v19.8b, v19.8b  // now each element contains 4
+
+  ushr      v20.8b, v3.8b, #4
+  ushl      v21.8b, v7.8b, v19.8b
+  bit       v7.8b, v20.8b, v18.8b
+  bif       v3.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v2.8b, #4
+  ushl      v21.8b, v6.8b, v19.8b
+  bit       v6.8b, v20.8b, v18.8b
+  bif       v2.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v1.8b, #4
+  ushl      v21.8b, v5.8b, v19.8b
+  bit       v5.8b, v20.8b, v18.8b
+  bif       v1.8b, v21.8b, v18.8b
+
+  ushr      v20.8b, v0.8b, #4
+  ushl      v21.8b, v4.8b, v19.8b
+  bit       v4.8b, v20.8b, v18.8b
+  bif       v0.8b, v21.8b, v18.8b
+
+  zip1      v20.16b, v7.16b, v6.16b
+  zip1      v21.16b, v5.16b, v4.16b
+  zip1      v22.16b, v3.16b, v2.16b
+  zip1      v23.16b, v1.16b, v0.16b
+
+  zip2      v0.8h, v20.8h, v21.8h
+  zip1      v1.8h, v20.8h, v21.8h
+  zip2      v2.8h, v22.8h, v23.8h
+  zip1      v3.8h, v22.8h, v23.8h
+
+  zip2      v5.4s, v1.4s, v3.4s
+  zip1      v7.4s, v1.4s, v3.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+  
+  cmp       x1, #1    // Exit from here if odd number of words
+  beq       NEON_doline_n8_exit
+   
+  subs      x1, x1, #2    // We handle 2 words (64 bit) per loop: wordcount -= 2
+
+  zip2      v5.4s, v0.4s, v2.4s
+  zip1      v7.4s, v0.4s, v2.4s
+
+  uzp2      v4.2d, v5.2d, v5.2d
+  uzp2      v6.2d, v7.2d, v7.2d
+
+  st4       { v4.d, v5.d, v6.d, v7.d }[0], [x0], #32
+
+  bgt       NEON_doline_n8_loop
+
+NEON_doline_n8_exit:
+  ret
+
+
+.align 8
+
+Masks_rgb:
+  .long 0x0000f800, 0x000007e0
+
+Lookup_doline_n1:
+  .long 0x00000000, 0x01000000, 0x00010000, 0x01010000
+  .long 0x00000100, 0x01000100, 0x00010100, 0x01010100
+  .long 0x00000001, 0x01000001, 0x00010001, 0x01010001
+  .long 0x00000101, 0x01000101, 0x00010101, 0x01010101
+
+.section        __TEXT,__cstring,cstring_literals
+debug.str:
+  .asciz	"Dst was %p, Src was %p, offset is %lx, New is %p\n";

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -205,7 +205,11 @@ extern void SetLastActiveConfig(const char* filename);
 char start_path_data[MAX_DPATH];
 char current_dir[MAX_DPATH];
 
+#ifndef __MACH__
 #include <linux/kd.h>
+#else
+#include <CoreFoundation/CoreFoundation.h>
+#endif
 #include <sys/ioctl.h>
 unsigned char kbd_led_status;
 char kbd_flags;
@@ -3042,7 +3046,13 @@ static void init_amiberry_paths(void)
 	snprintf(rom_path, MAX_DPATH, "%s/kickstarts/", start_path_data);
 #endif
 	snprintf(rp9_path, MAX_DPATH, "%s/rp9/", start_path_data);
+#ifdef __MACH__
+	// Open amiberry.conf from app bundle which provided reasonable OS X M1 defaults
+	snprintf(amiberry_conf_file, MAX_DPATH, "%s",prefix_with_application_directory_path("conf/amiberry.conf").c_str());
+	printf("%s\n",prefix_with_application_directory_path("conf/amiberry.conf").c_str());
+#else
 	snprintf(amiberry_conf_file, MAX_DPATH, "%s/conf/amiberry.conf", start_path_data);
+#endif
 	snprintf(floppy_sounds_dir, MAX_DPATH, "%s/data/floppy_sounds/", start_path_data);
 	snprintf(data_dir, MAX_DPATH, "%s/", start_path_data);
 	snprintf(saveimage_dir, MAX_DPATH, "%s/savestates/", start_path_data);
@@ -3276,7 +3286,8 @@ int main(int argc, char* argv[])
 
 	normalcursor = SDL_GetDefaultCursor();
 	clipboard_init();
-	
+
+#ifndef __MACH__
 	// set capslock state based upon current "real" state
 	ioctl(0, KDGKBLED, &kbd_flags);
 	ioctl(0, KDGETLED, &kbd_led_status);
@@ -3293,6 +3304,22 @@ int main(int argc, char* argv[])
 		inputdevice_do_keyboard(AK_CAPSLOCK, 0);
 	}
 	ioctl(0, KDSETLED, kbd_led_status);
+#else
+	// I tried to use Apple IO KIT to poll the status of the various leds but it requires a special input reading permission (that the user needs to explicitely allow 
+	// for the app on launch) and in addition to that it doesn't consistently work well enough, more often than not we'll get a permission denied from the IOKIT framework 
+	// which causes the app to silently fail anyway.  I can't find recent examples for Mac OS that work well enough and I feel it's not good to rely on a framework that
+	// doesn't work all the time
+
+	// We'll just call SDL and do a rudimentary state check instead
+	int caps = SDL_GetModState();
+        caps = caps & KMOD_CAPS;
+	if(caps == KMOD_CAPS)
+		// 0x04 is LED_CAP in the Linux file which is used here to trigger it
+		kbd_led_status |= ~0x04;
+	else
+		kbd_led_status &= ~0x04;
+#endif
+
 
 #ifdef USE_GPIOD
 	// Open GPIO chip
@@ -3319,8 +3346,12 @@ int main(int argc, char* argv[])
 
 	gpiod_chip_close(chip);
 #endif
+#ifndef __MACH__
 	// restore keyboard LEDs to normal state
 	ioctl(0, KDSETLED, 0xFF);
+#else
+	// TODO
+#endif
 
 	ClearAvailableROMList();
 	romlist_clear();

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -3350,7 +3350,7 @@ int main(int argc, char* argv[])
 	// restore keyboard LEDs to normal state
 	ioctl(0, KDSETLED, 0xFF);
 #else
-	// TODO
+	// Unsolved for OS X
 #endif
 
 	ClearAvailableROMList();

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -912,6 +912,8 @@ static void open_screen(struct uae_prefs* p)
 		
 		if (isfullscreen() == 0 && !is_maximized)
 			SDL_SetWindowSize(mon->sdl_window, display_width, display_height);
+			// Center window, sigurbjornl 20220122
+			SDL_SetWindowPosition(mon->sdl_window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 	}
 	else
 	{
@@ -1843,6 +1845,37 @@ int graphics_init(bool mousecapture)
 			0,
 			0,
 			SDL_WINDOW_FULLSCREEN_DESKTOP);
+		check_error_sdl(mon->sdl_window == nullptr, "Unable to create window");
+	}
+#elif defined __MACH__
+// On OS X set the SDL_WINDOW_ALLOW_HIGHDPI on Mac OS X since monitor is likely to be high DPI but otherwise listen to prefs
+	// If window isn't open already
+	if (!mon->sdl_window)
+	{
+		// Variable to OR together the window mode settings
+		Uint32 sdl_window_mode;
+		// Obey prefs for fullscreen window or full screen mode
+		if (currprefs.gfx_apmode[0].gfx_fullscreen == GFX_FULLWINDOW)
+			sdl_window_mode = SDL_WINDOW_FULLSCREEN_DESKTOP;
+		else if (currprefs.gfx_apmode[0].gfx_fullscreen == GFX_FULLSCREEN)
+			sdl_window_mode = SDL_WINDOW_FULLSCREEN;
+		else
+			sdl_window_mode = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
+		// Obey prefs for Borderless
+		if (currprefs.borderless)
+			sdl_window_mode |= SDL_WINDOW_BORDERLESS;
+		// And always on top
+		if (currprefs.main_alwaysontop)
+			sdl_window_mode |= SDL_WINDOW_ALWAYS_ON_TOP;
+		// Set Window allow high DPI by default on OS X
+		sdl_window_mode |= SDL_WINDOW_ALLOW_HIGHDPI;
+		// Open centered window with window mode settings
+		mon->sdl_window = SDL_CreateWindow("Amiberry",
+			SDL_WINDOWPOS_CENTERED,
+			SDL_WINDOWPOS_CENTERED,
+			0,
+			0,
+			sdl_window_mode);
 		check_error_sdl(mon->sdl_window == nullptr, "Unable to create window");
 	}
 #else

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -30,7 +30,9 @@
 #include "drawing.h"
 
 #ifdef AMIBERRY
+#ifndef __MACH__
 #include <linux/kd.h>
+#endif
 #include <sys/ioctl.h>
 #endif
 
@@ -681,7 +683,7 @@ void gui_led(int led, int on, int brightness)
 	if (currprefs.kbd_led_num != changed_prefs.kbd_led_num) currprefs.kbd_led_num = changed_prefs.kbd_led_num;
 	if (currprefs.kbd_led_scr != changed_prefs.kbd_led_scr) currprefs.kbd_led_scr = changed_prefs.kbd_led_scr;
 	//if (currprefs.kbd_led_cap != changed_prefs.kbd_led_cap) currprefs.kbd_led_cap = changed_prefs.kbd_led_cap;
-
+#ifndef __MACH__
 	ioctl(0, KDGETLED, &kbd_led_status);
 
 	// Handle floppy led status
@@ -690,6 +692,7 @@ void gui_led(int led, int on, int brightness)
 		if (currprefs.kbd_led_num == led)
 		{
 			if (on) kbd_led_status |= LED_NUM;
+			
 			else kbd_led_status &= ~LED_NUM;
 		}
 		if (currprefs.kbd_led_scr == led)
@@ -724,6 +727,9 @@ void gui_led(int led, int on, int brightness)
 	}
 
 	ioctl(0, KDSETLED, kbd_led_status);
+#else
+	// TODO
+#endif
 }
 
 void gui_filename(int num, const char* name)

--- a/src/osdep/amiberry_hardfile.cpp
+++ b/src/osdep/amiberry_hardfile.cpp
@@ -30,6 +30,13 @@ struct uae_driveinfo {
 	int readonly;
 };
 
+#ifdef __MACH__
+#  define off64_t off_t
+#  define fopen64 fopen
+#  define fseeko64 fseeko
+#  define ftello64 ftello
+#endif
+
 #define HDF_HANDLE_WIN32  1
 #define HDF_HANDLE_ZFILE 2
 #define HDF_HANDLE_LINUX 3

--- a/src/osdep/amiberry_mem.cpp
+++ b/src/osdep/amiberry_mem.cpp
@@ -9,7 +9,9 @@
 #include "uae/mman.h"
 #include <sys/mman.h>
 #include "sys/types.h"
+#ifndef __MACH__
 #include "sys/sysinfo.h"
+#endif
 
 #ifdef ANDROID
 #define valloc(x) memalign(getpagesize(), x)
@@ -59,6 +61,7 @@ void free_AmigaMem(void)
 
 bool can_have_1gb()
 {
+	#ifndef __MACH__
 	struct sysinfo mem_info{};
 	sysinfo(&mem_info);
 	long long total_phys_mem = mem_info.totalram;
@@ -67,6 +70,10 @@ bool can_have_1gb()
 	if (total_phys_mem > 2147483648LL)
 		return true;
 	return false;
+	#else
+	// On OSX just return true, there's no M1 mac with less than 8G of RAM
+	return true;
+	#endif
 }
 
 void alloc_AmigaMem(void)

--- a/src/osdep/bsdsocket_host.cpp
+++ b/src/osdep/bsdsocket_host.cpp
@@ -1020,7 +1020,7 @@ uae_u32 host_bind(TrapContext *ctx, SB, uae_u32 sd, uae_u32 name, uae_u32 namele
 	write_log("bind(%u[%d], 0x%x, %u) -> ", sd, s, name, namelen);
 	copysockaddr_a2n (&addr, name, namelen);
 	printSockAddr (&addr);
-	if ((success = bind (s, (struct sockaddr *)&addr, len)) != 0) {
+	if ((success = ::bind (s, (struct sockaddr *)&addr, len)) != (uae_u32)0) {
 		SETERRNO;
 		write_log("failed (%d)\n",sb->sb_errno);
 	} else {

--- a/src/osdep/sysconfig.h
+++ b/src/osdep/sysconfig.h
@@ -572,7 +572,7 @@ typedef char TCHAR;
 #define _timezone           timezone
 #define _daylight           daylight
 // Ftello and fseeko on OSX are alerady 64bit
-#ifdef ANDROID or defined __MACH__
+#if defined ANDROID || defined __MACH__
 #define _ftelli64(x)        ftello(x)
 #define _fseeki64(x,y,z)    fseeko(x,y,z)
 #else

--- a/src/osdep/sysconfig.h
+++ b/src/osdep/sysconfig.h
@@ -571,7 +571,8 @@ typedef char TCHAR;
 #define _tzset()            tzset()
 #define _timezone           timezone
 #define _daylight           daylight
-#ifdef ANDROID
+// Ftello and fseeko on OSX are alerady 64bit
+#ifdef ANDROID or defined __MACH__
 #define _ftelli64(x)        ftello(x)
 #define _fseeki64(x,y,z)    fseeko(x,y,z)
 #else
@@ -580,4 +581,5 @@ typedef char TCHAR;
 #endif
 #define _wunlink(x)         unlink(x)
 #define _istalnum(x)        isalnum(x)
+
 

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -36,6 +36,7 @@ STATIC_INLINE FILE* uae_tfopen(const TCHAR* path, const TCHAR* mode)
 	return fopen(path, mode);
 }
 
+// Expose prefix_with_application_directory from amiberry_filesys so we can use it to open the main confguration file on OS X
 extern int mouseactive;
 extern int minimized;
 extern int monitor_off;
@@ -85,6 +86,11 @@ extern void keyboard_settrans(void);
 extern void free_AmigaMem();
 extern void alloc_AmigaMem();
 extern bool can_have_1gb();
+
+#ifdef __MACH__
+// from amifilesys.cpp
+string prefix_with_application_directory_path(string currentpath);
+#endif
 
 extern void get_configuration_path(char* out, int size);
 extern void set_configuration_path(char* newpath);

--- a/src/scp.cpp
+++ b/src/scp.cpp
@@ -18,6 +18,22 @@
 //#include "uae/endian.h"
 
 #include <stdint.h>
+#if defined __MACH__
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#endif
 
 #define MAX_REVS 5
 

--- a/src/zfile.cpp
+++ b/src/zfile.cpp
@@ -24,6 +24,13 @@
 #include "diskutil.h"
 #include "fdi2raw.h"
 #include "uae.h"
+// OS X does not have off64_t, fopen64, fseeko64 or ftello64, the functions are already 64bit
+#ifdef __MACH__
+#  define off64_t off_t
+#  define fopen64 fopen
+#  define fseeko64 fseeko
+#  define ftello64 ftello
+#endif
 
 #include "archivers/zip/unzip.h"
 #include "archivers/dms/pfile.h"


### PR DESCRIPTION
Fixes for OS X

- Added build platform osx, make PLATFORM=osx will build for Mac OS X 12/12.1 for ARM
- Added aarch64_helper_osx.s with fixes for ARM64 on OS X
- Don't include linux specific include files on OS X
- Fixes for various OS X specific behaviour including difference in the sigsegv handler, serial code and others
- Some changes to SDL2 behaviour on OS X, including enabling High DPI mode by default
- Script for building App bundle on OS X and installing user specific files into Documents/Amiberry
- JIT does not work on OS X due to 32 bit access space dependancy, will crash if enabled