### PR TITLE
Moved resource creation to runtime

### DIFF
--- a/Info.plist.template
+++ b/Info.plist.template
@@ -6,7 +6,7 @@
 		<key>CFBundleGetInfoString</key>
 			<string>LONGVERSION</string>
 		<key>CFBundleExecutable</key>
-			<string>amiberry</string>
+			<string>run_amiberry.zsh</string>
 		<key>CFBundleIdentifier</key>
 			<string>com.midwan.amiberry</string>
 		<key>CFBundleName</key>

--- a/make-bundle.sh
+++ b/make-bundle.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 USERDIR=`echo ~`
 
@@ -7,8 +7,6 @@ VERSION=`echo $LONGVER | awk -F v '{printf $2}' | awk '{print $1}'`
 MAJOR=`echo $VERSION | awk -F . '{printf $1}'`
 MINOR=`echo $VERSION | awk -F . '{printf $2}'`
 
-
-cat Info.plist.template | sed -e "s/LONGVERSION/$LONGVER/" | sed -e "s/VERSION/$VERSION/" | sed -e "s/MAJOR/$MAJOR/" | sed -e "s/MINOR/$MINOR/" >Info.plist
 echo "Removing old App directory"
 rm -Rf Amiberry.app
 echo "Creating App directory"
@@ -18,35 +16,27 @@ mkdir -p Amiberry.app/Contents/Frameworks
 mkdir -p Amiberry.app/Contents/Resources
 # Copy executable into App bundle
 cp amiberry Amiberry.app/Contents/MacOS/Amiberry
+# Copy launch script into the bundle
+cp run_amiberry.zsh Amiberry.app/Contents/MacOS
+chmod +x Amiberry.app/Contents/MacOS/run_amiberry.zsh
 # Copy parameter list into the bundle
-cp Info.plist Amiberry.app/Contents/Info.plist
+cat Info.plist.template | sed -e "s/LONGVERSION/$LONGVER/" | sed -e "s/VERSION/$VERSION/" | sed -e "s/MAJOR/$MAJOR/" | sed -e "s/MINOR/$MINOR/" > Amiberry.app/Contents/Info.plist
 # Self-sign binary
 export CODE_SIGN_ENTITLEMENTS=Entitlements.plist
 codesign --entitlements=Entitlements.plist --force -s - Amiberry.app
-# Copy Guisan library into the bundle
-cp external/libguisan/dylib/libguisan.dylib Amiberry.app/Contents/MacOS
-# Install libguisan lib into app bundle
-# Copy docs into the bundle
-cp -R docs Amiberry.app/Contents/Resources
-# Copy data into the bundle
-cp -R data Amiberry.app/Contents/Resources
+# Copy OSX specific conf template into the bundle
+cp -R conf Amiberry.app/Contents/Resources/Configurations
+# Copy controllers into the bundle
+cp -R controllers Amiberry.app/Contents/Resources/Controllers
 # Copy kickstarts into the bundle
-cp -R kickstarts Amiberry.app/Contents/Resources
-# Overwrite default conf with OSX specific one
-mkdir Amiberry.app/Contents/resources/conf
-cat conf/amiberry-osx.conf | sed -e "s#USERDIR#$USERDIR#g" >Amiberry.app/Contents/Resources/conf/amiberry.conf
+cp -R kickstarts Amiberry.app/Contents/Resources/Kickstarts
+# Copy data into the bundle
+cp -R data Amiberry.app/Contents/Resources/Data
+# Copy docs into the bundle
+cp -R docs Amiberry.app/Contents/Resources/Docs
+
 # Use dylibbundler to install into app if exists
 dylibbundler -od -b -x Amiberry.app/Contents/MacOS/Amiberry -d Amiberry.app/Contents/libs/ -s external/libguisan/dylib/
 if [ $? -gt 0 ]; then
-	echo "Can't find dylibbundler, use brew to install it, or manually copy external/libguisan/dylib/libguisan.dylib into /usr/local/lib (you'll need sudo)"
+	echo "Can't find dylibbundler, use brew to install it, or have users manually copy external/libguisan/dylib/libguisan.dylib into /usr/local/lib (needs sudo)"
 fi
-
-# Create application directories
-mkdir -p ~/Documents/Amiberry/Hard\ Drives ~/Documents/Amiberry/Configurations ~/Documents/Amiberry/Controllers ~/Documents/Amiberry/Logfiles ~/Documents/Amiberry/Kickstarts ~/Documents/Amiberry/RP9 ~/Documents/Amiberry/Data/Floppy_Sounds ~/Documents/Amiberry/Savestates ~/Documents/Amiberry/Screenshots ~/Documents/Amiberry/Docs
-
-# Copy files to their destination
-cp -a conf/* ~/Documents/Amiberry/Configurations
-cp -a controllers/* ~/Documents/Amiberry/Controllers
-cp -a kickstarts/* ~/Documents/Amiberry/Kickstarts
-cp -a data/* ~/Documents/Amiberry/Data
-cp -a docs/* ~/Documents/Amiberry/Docs

--- a/run_amiberry.zsh
+++ b/run_amiberry.zsh
@@ -1,0 +1,96 @@
+#!/usr/bin/env zsh
+
+CWD_VAR=$(cd "$(dirname "$0")"; pwd)
+USERDIR=`echo ~`
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Hard Drives" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Hard Drives"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Configurations" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Configurations"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Controllers" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Controllers"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Logfiles" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Logfiles"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Kickstarts" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Kickstarts"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/RP9" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/RP9"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Data/Floppy_Sounds" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Data/Floppy_Sounds"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Savestates" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Savestates"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Screenshots" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Screenshots"
+fi
+
+if [[ ! -d "$USERDIR/Documents/Amiberry/Docs" ]]; then
+	mkdir -p "$USERDIR/Documents/Amiberry/Docs"
+fi
+
+if [[ ! -f "$USERDIR/Documents/Amiberry/Configurations/amiberry.conf" ]]; then
+	cat $CWD_VAR/../Resources/Configurations/amiberry-osx.conf | sed -e "s#USERDIR#$USERDIR#g" > "$USERDIR/Documents/Amiberry/Configurations/amiberry.conf"
+fi
+
+for file in $CWD_VAR/../Resources/Configurations/**/*(.); do
+	if [[ "$file" != "$CWD_VAR/../Resources/Configurations/amiberry-osx.conf" ]]; then
+		if [[ "$file" != "$CWD_VAR/../Resources/Configurations/amiberry.conf" ]]; then
+			if [[ ! -f "$USERDIR/Documents/Amiberry/Configurations${file##*/Configurations}" ]]; then
+				echo "Copying $file to $USERDIR/Documents/Amiberry/Configurations${file##*/Configurations}"
+				mkdir -p $(dirname "$USERDIR/Documents/Amiberry/Configurations${file##*/Configurations}")
+				cp $file "$USERDIR/Documents/Amiberry/Configurations${file##*/Configurations}"
+			fi
+		fi
+	fi
+done
+
+for file in $CWD_VAR/../Resources/Controllers/**/*(.); do
+	if [[ ! -f "$USERDIR/Documents/Amiberry/Controllers${file##*/Controllers}" ]]; then
+		echo "Copying $file to $USERDIR/Documents/Amiberry/Controllers${file##*/Controllers}"
+		mkdir -p $(dirname "$USERDIR/Documents/Amiberry/Controllers${file##*/Controllers}")
+		cp $file "$USERDIR/Documents/Amiberry/Controllers${file##*/Controllers}"
+	fi
+done
+
+for file in $CWD_VAR/../Resources/Kickstarts/**/*(.); do
+	if [[ ! -f "$USERDIR/Documents/Amiberry/Kickstarts${file##*/Kickstarts}" ]]; then
+		echo "Copying $file to $USERDIR/Documents/Amiberry/Kickstarts${file##*/Kickstarts}"
+		mkdir -p $(dirname "$USERDIR/Documents/Amiberry/Kickstarts${file##*/Kickstarts}")
+		cp $file "$USERDIR/Documents/Amiberry/Kickstarts${file##*/Kickstarts}"
+	fi
+done
+
+for file in $CWD_VAR/../Resources/Data/**/*(.); do
+	if [[ ! -f "$USERDIR/Documents/Amiberry/Data${file##*/Data}" ]]; then
+		echo "Copying $file to $USERDIR/Documents/Amiberry/Data${file##*/Data}"
+		mkdir -p $(dirname "$USERDIR/Documents/Amiberry/Data${file##*/Data}")
+		cp $file "$USERDIR/Documents/Amiberry/Data${file##*/Data}"
+	fi
+done
+
+for file in $CWD_VAR/../Resources/Docs/**/*(.); do
+	if [[ ! -f "$USERDIR/Documents/Amiberry/Docs${file##*/Docs}" ]]; then
+		echo "Copying $file to $USERDIR/Documents/Amiberry/Docs${file##*/Docs}"
+		mkdir -p $(dirname "$USERDIR/Documents/Amiberry/Docs${file##*/Docs}")
+		cp $file "$USERDIR/Documents/Amiberry/Docs${file##*/Docs}"
+	fi
+done
+
+echo "Running Amiberry"
+
+$CWD_VAR/Amiberry

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -52,6 +52,10 @@
 #include "threaddep/thread.h"
 #include "uae/uae.h"
 
+#ifdef __MACH__
+#include <string>
+#endif
+
 #ifdef AHI
 #include "ahi_v1.h"
 #ifdef AHI_v2
@@ -3071,9 +3075,10 @@ static void init_amiberry_paths(void)
 #endif
 	snprintf(rp9_path, MAX_DPATH, "%s/rp9/", start_path_data);
 #ifdef __MACH__
-	// Open amiberry.conf from app bundle which provided reasonable OS X M1 defaults
-	snprintf(amiberry_conf_file, MAX_DPATH, "%s",prefix_with_application_directory_path("conf/amiberry.conf").c_str());
-	printf("%s\n",prefix_with_application_directory_path("conf/amiberry.conf").c_str());
+	// Open amiberry.conf from Application Data directory
+	string macos_home_directory = getenv("HOME");
+	snprintf(amiberry_conf_file, MAX_DPATH, "%s", (macos_home_directory + "/Documents/Amiberry/Configurations/amiberry.conf").c_str());
+	printf("Using configuration: %s\n", (macos_home_directory + "/Documents/Amiberry/Configurations/amiberry.conf").c_str());
 #else
 	snprintf(amiberry_conf_file, MAX_DPATH, "%s/conf/amiberry.conf", start_path_data);
 #endif


### PR DESCRIPTION
Changes proposed in this pull request:
- Moves macOS environment setup/configuration generation/resource copying from compile time to run time, in order to allow for app bundle distribution to other people

@midwan
