### PR TITLE
Restore hardware interrupt; fix RTG for M1 MAX and possibly others

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -17,7 +17,7 @@
 
 #define UAEMAJOR 5
 #define UAEMINOR 2
-#define UAESUBREV 0
+#define UAESUBREV 1
 
 #define MAX_AMIGADISPLAYS 1
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,7 +64,7 @@
 #include "fsdb_host.h"
 #include "keyboard.h"
 
-static const char __ver[40] = "$VER: Amiberry 5.2 (2022-05-19)";
+static const char __ver[40] = "$VER: Amiberry 5.2.1 (2022-06-19)";
 long int version = 256 * 65536L * UAEMAJOR + 65536L * UAEMINOR + UAESUBREV;
 
 struct uae_prefs currprefs, changed_prefs;

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -5958,6 +5958,9 @@ static void inituaegfxfuncs(TrapContext *ctx, uaecptr start, uaecptr ABI)
 		RTGCALL2(PSSO_BoardInfo_CoerceMode, picasso_CoerceMode);
 	}
 
+	if (currprefs.rtg_hardwareinterrupt)
+		RTGCALL2(PSSO_BoardInfo_SetInterrupt, picasso_SetInterrupt);
+
 	write_log (_T("uaegfx.card magic code: %08X-%08X BI=%08X\n"), start, here (), ABI);
 
 	if (ABI && currprefs.rtg_hardwareinterrupt)

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -24,7 +24,7 @@
 #define GETBDM(x) (((x) - (((x) / 10000) * 10000)) / 100)
 #define GETBDD(x) ((x) % 100)
 
-#define AMIBERRYVERSION _T("Amiberry v5.2 (2022-05-19)")
+#define AMIBERRYVERSION _T("Amiberry v5.2.1 (2022-06-19)")
 #define AMIBERRYDATE MAKEBD(2022, 5, 19)
 
 #define IHF_WINDOWHIDDEN 6


### PR DESCRIPTION
The hardware interrupt was removed during some WinUAE adaptations between 5.1 and 5.2. This caused RTG modes to fail for some hardware, including mine. My machine is a M1 MAX MacBook Pro.

This PR simply adds those lines back in. They seem to work on my machine if done.

Fixes https://github.com/midwan/amiberry/issues/983

Changes proposed in this pull request:
 * Restore hardware interrupt and fix regression
 * Bumped version to 5.2.1

@midwan
