### PR TITLE
Respect active_capture_automatically on non-gui startup

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -866,9 +866,10 @@ static void amiberry_active(const AmigaMonitor* mon, const int is_minimized)
 	}
 	getcapslock();
 	wait_keyrelease();
-	inputdevice_acquire(TRUE);
-	if (isfullscreen() > 0 || currprefs.capture_always)
+	if (isfullscreen() > 0 || currprefs.capture_always) {
 		setmouseactive(mon->monitor_id, 1);
+		inputdevice_acquire(TRUE);
+	}
 	clipboard_active(1, 1);
 }
 

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -2251,7 +2251,8 @@ static void open_screen(struct uae_prefs* p)
 	init_colors(mon->monitor_id);
 	target_graphics_buffer_update(mon->monitor_id, false);
 	picasso_refresh(mon->monitor_id);
-	setmouseactive(mon->monitor_id, -1);
+	if (isfullscreen() > 0 || currprefs.capture_always)
+		setmouseactive(mon->monitor_id, -1);
 
 	if (vkbd_allowed(0))
 	{
@@ -2537,7 +2538,8 @@ int graphics_init(bool mousecapture)
 	inputdevice_unacquire();
 	graphics_subinit();
 
-	inputdevice_acquire(TRUE);
+	if (isfullscreen() > 0 || currprefs.capture_always)
+		inputdevice_acquire(TRUE);
 	return 1;
 }
 


### PR DESCRIPTION
Fixes #1700.

Changes proposed in this pull request:
- Prevent capturing mouse on startup without GUI if `active_capture_automatically` is off

@midwan
