### PR TITLE
Fix time zone difference in files (fixes #1643)

### DIFF
--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -426,6 +426,16 @@ std::string prefix_with_data_path(const std::string& filename)
 	}
 }
 
+[[nodiscard]] static time_t get_local_time_offset(time_t t)
+{
+	struct tm lt{};
+	localtime_r(&t, &lt);
+	struct tm gt{};
+	gmtime_r(&t, &gt);
+	gt.tm_isdst = lt.tm_isdst;
+	return t - mktime(&gt);
+}
+
 [[nodiscard]] bool my_stat(const TCHAR* name, struct mystat* statbuf) noexcept
 {
 	try {
@@ -460,7 +470,7 @@ std::string prefix_with_data_path(const std::string& filename)
 		statbuf->size = st.st_size;
 		statbuf->mode = ((file_status.permissions() & fs::perms::owner_read) != fs::perms::none ? FILEFLAG_READ : 0) |
 			((file_status.permissions() & fs::perms::owner_write) != fs::perms::none ? FILEFLAG_WRITE : 0);
-		statbuf->mtime.tv_sec = st.st_mtime;
+		statbuf->mtime.tv_sec = st.st_mtime + get_local_time_offset(st.st_mtime);
 		statbuf->mtime.tv_usec = 0;
 
 		return true;


### PR DESCRIPTION
Fixes # https://github.com/BlitterStudio/amiberry/issues/1643.

Changes proposed in this pull request:
- calculates the local time zone offset and then subtract it from the UTC timestamp to obtain the correct local time

<img width="583" height="256" alt="Screenshot 2025-11-01 at 11 40 54 PM" src="https://github.com/user-attachments/assets/c6518ca3-d6f0-4889-890f-16e6331dab6b" />


@midwan
