### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ option(USE_GPIOD         "Use GPIOD to control GPIO LEDs" OFF)
 option(USE_DBUS          "Use DBus to control the emulator" OFF)
 option(USE_OPENGL        "Use OpenGL for rendering (currently BROKEN)" OFF)
 option(WITH_LTO          "Enable Link Time Optimization" OFF)
+option(WITH_OPTIMIZE     "Enable GCC native CPU optimizations" OFF)
 
 # Automatically disable PCem on RISC-V targets
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv" OR CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "riscv")

--- a/cmake/optimize.cmake
+++ b/cmake/optimize.cmake
@@ -1,22 +1,19 @@
-if(DEFINED TOOLCHAIN_ALREADY_RUN)
+# Extract GCC native optimization flags
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(WARNING "GCC optimization flags do not support Clang. Skipping.")
     return()
 endif()
-# Set the guard variable, because for some strange reason it's run twice if not set.
-set(TOOLCHAIN_ALREADY_RUN TRUE CACHE INTERNAL "Toolchain file has already been processed")
 
-if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    message(FATAL_ERROR "This toolchain file does not support Clang. Please use GCC or another supported compiler.")
-endif()
-
-# Check if cross-compiling is being attempted
-if(CMAKE_CROSSCOMPILING)
-    message(FATAL_ERROR "This toolchain file cannot be used for cross-compilation.")
-endif()
-
-
-# Run gcc to get the compilation details and remove unwanted flags after -dumpbase
 execute_process(
-        COMMAND sh -c "gcc -### -E - -march=native -mtune=native -mcpu=native 2>&1 | sed -r '/cc1/!d; s/\"//g; s/^.* - //g; s/ -dumpbase.*//'"
-        OUTPUT_VARIABLE OPTIMIZED_C_FLAGS
-        OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND sh -c "gcc -### -E - -march=native -mtune=native -mcpu=native 2>&1 | sed -r '/cc1/!d; s/\"//g; s/^.* - //g; s/ -dumpbase.*//'"
+    OUTPUT_VARIABLE OPTIMIZED_C_FLAGS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+
+if(OPTIMIZED_C_FLAGS)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OPTIMIZED_C_FLAGS}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPTIMIZED_C_FLAGS}")
+    message(STATUS "Applied GCC optimization flags: ${OPTIMIZED_C_FLAGS}")
+else()
+    message(WARNING "Could not extract GCC optimization flags")
+endif()


### PR DESCRIPTION
Add parallel LTO compilation and support check & add WITH_OPTIMIZE option for GCC native CPU optimizations

- Add GCC support with -flto=auto for automatic CPU core detection
- Add Clang support with -flto=thin for ThinLTO parallelization
- Improves build performance when WITH_LTO=ON is enabled
- Add CheckIPOSupported to verify LTO availability before enabling
- Add WITH_OPTIMIZE CMake option to enable GCC-specific CPU optimizations
- Refactor cmake/optimize.cmake from toolchain file to simple CMake module
- Extracts optimal GCC flags using -march=native detection
- Works with distcc (uses specific CPU flags, not -march=native)
- Gracefully handles Clang with warning and skip
- Can be combined with WITH_LTO for maximum performance


@midwan
