### PR TITLE
Fix linker flags for FreeBSD (remove GNU ld-only options) and updated uaelib.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,5 +105,13 @@ add_subdirectory(packaging)
 
 # Link libraries (FreeBSD needs correct order)
 if(TARGET amiberry AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    # forkpty() lives in libutil on FreeBSD
+    target_link_libraries(amiberry PRIVATE util)
+
+    # libiconv_* symbols come from ports/converters/libiconv
+    find_library(LIBICONV_LIBRARY NAMES iconv PATHS /usr/local/lib REQUIRED)
+    target_link_libraries(amiberry PRIVATE ${LIBICONV_LIBRARY})
+
+    # existing libs
     target_link_libraries(amiberry PRIVATE ${LIBUSB_LIBRARY} serialport ${EXTRA_LIBS})
 endif()

--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -45,15 +45,22 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
             "-Wl,-O1"
             "-Wl,-z,relro"
             "-Wl,-z,now"
-            "-Wl,--sort-common=descending"
-            "-Wl,--hash-style=gnu"
         )
+
+        # GNU ld-only flags (do not work on FreeBSD)
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            add_link_options(
+                "-Wl,--sort-common=descending"
+                "-Wl,--hash-style=gnu"
+            )
+        endif()
     endif()
 else()
     if(CMAKE_BUILD_TYPE STREQUAL "Release")
         add_link_options("-Wl,-dead_strip")
     endif()
 endif()
+
 
 # Set build type to "Release" if user did not specify any build type yet
 # Other possible values: Debug and None. 

--- a/src/uaelib.cpp
+++ b/src/uaelib.cpp
@@ -390,13 +390,15 @@ struct ShellSession {
 #include <sys/wait.h>
 #include <fcntl.h>
 #include <signal.h>
-#if !defined(_WIN32)
-#if defined(__APPLE__) || defined(__FreeBSD__)
-#include <util.h>
-#else
-#include <pty.h>
-#endif
-#endif
+#if !defined(_WIN32)                                                                                                       
+  #if defined(__APPLE__)                                                                                                   
+    #include <util.h>                                                                                                      
+  #elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__) || defined(__OpenBSD__)                      
+    #include <libutil.h>                                                                                                   
+  #else                                                                                                                    
+    #include <pty.h>                                                                                                       
+  #endif                                                                                                                   
+#endif             
 
 static std::map<uae_u32, ShellSession> shell_sessions;
 static uae_u32 next_session_handle = 1;


### PR DESCRIPTION
Fixes # . Fix linker flags for FreeBSD (remove GNU ld-only options)
Put in a check in uaelib.cpp that if FreeBSD then use libutil.h instead of util.h

@midwan
