### PR TITLE
fix: populate device_settings when parsing a2065 config on Amiberry builds

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -5955,8 +5955,14 @@ static int cfgfile_parse_hardware (struct uae_prefs *p, const TCHAR *option, TCH
 
 
 	if (cfgfile_string(option, value, _T("a2065"), p->a2065name, sizeof p->a2065name / sizeof(TCHAR))) {
-		if (p->a2065name[0])
+		if (p->a2065name[0]) {
 			addbcromtype(p, ROMTYPE_A2065, true, nullptr, 0);
+			struct romconfig *rc = get_device_romconfig(p, ROMTYPE_A2065, 0);
+			if (rc && !rc->device_settings) {
+				ethernet_updateselection();
+				rc->device_settings = ethernet_getselection(p->a2065name);
+			}
+		}
 		return 1;
 	}
 


### PR DESCRIPTION
## Summary

The `a2065=<device>` config line is parsed and stored, but the PCAP device index (`device_settings`) is never set, causing the A2065 emulation to silently fall back to SLIRP NAT mode regardless of the configured device.

## The Problem

When `a2065=br0` (or any PCAP device) is parsed in `cfgfile_parse_hardware()`, the device name is stored in `p->a2065name` and `addbcromtype()` creates the board ROM entry. However, the code that would convert the device name to a `device_settings` index lives in `addbcromtypenet()`, which is:

1. Guarded by `#ifndef AMIBERRY` (line 6808), so it's compiled out of Amiberry builds entirely
2. Further gated behind a `config_version < 3.4.0` check, which fails for current configs (version 7.x)

As a result, `device_settings` stays at its default value of 0. At runtime, `ethernet_getselectionname(0)` maps index 0 to `"slirp"`, so the A2065 always uses SLIRP regardless of the config file.

**Config file says:**
```
a2065=br0
```

**What actually happens:**
```
a2065=br0 → p->a2065name = "br0" (stored but never used)
          → addbcromtype() creates entry, device_settings = 0
          → ethernet_getselectionname(0) → "slirp"
          → A2065 opens SLIRP instead of br0
```

## The Fix

After `addbcromtype()` creates the board entry, immediately resolve the device name to a PCAP device index via `ethernet_getselection()` and store it in `device_settings`. This mirrors what `addbcromtypenet()` does in the WinUAE code path.

## Testing

Tested on Debian 13 with `a2065=br0` in the UAE config file. Before the fix, Amiberry logs showed only SLIRP devices enumerated and no PCAP connection. After the fix, logs show:
```
7990: 'br0' 00:80:10:00:00:00
UAENET: Opening 'br0'
UAENET: 'br0' open successful
```

Confirmed the PCAP socket was bound to the correct interface via `/proc/net/packet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)