### PR TITLE
fix: rewrite PCAP backend for correct bridged networking

### DIFF
--- a/src/a2065.cpp
+++ b/src/a2065.cpp
@@ -598,6 +598,12 @@ static void a2065_hsync_handler(void)
 {
 	static int cnt;
 
+	// Deliver any received packets queued by the PCAP worker thread.
+	// Must be done here (emulation thread) to avoid concurrent access
+	// to Am7990 chip state (csr[], boardram, interrupts).
+	if (td && sysdata)
+		ethernet_receive_poll(td, sysdata);
+
 	cnt--;
 	if (cnt < 0 || transmitnow) {
 		check_transmit(false);

--- a/src/ethernet.cpp
+++ b/src/ethernet.cpp
@@ -107,6 +107,20 @@ void ethernet_trigger (struct netdriverdata *ndd, void *vsd)
 	}
 }
 
+void ethernet_receive_poll (struct netdriverdata *ndd, void *vsd)
+{
+	if (!ndd)
+		return;
+	switch (ndd->type)
+	{
+#ifdef WITH_UAENET_PCAP
+		case UAENET_PCAP:
+		uaenet_receive_poll (vsd);
+		return;
+#endif
+	}
+}
+
 int ethernet_open (struct netdriverdata *ndd, void *vsd, void *user, ethernet_gotfunc *gotfunc, ethernet_getfunc *getfunc, int promiscuous, const uae_u8 *mac)
 {
 	switch (ndd->type)

--- a/src/include/ethernet.h
+++ b/src/include/ethernet.h
@@ -32,6 +32,7 @@ extern int ethernet_getdatalength (struct netdriverdata *ndd);
 extern int ethernet_open (struct netdriverdata *ndd, void*, void*, ethernet_gotfunc*, ethernet_getfunc*, int, const uae_u8 *mac);
 extern void ethernet_close (struct netdriverdata *ndd, void*);
 extern void ethernet_trigger (struct netdriverdata *ndd, void*);
+extern void ethernet_receive_poll (struct netdriverdata *ndd, void*);
 
 extern bool ariadne2_init(struct autoconfig_info *aci);
 extern bool hydra_init(struct autoconfig_info *aci);

--- a/src/osdep/amiberry_uaenet.cpp
+++ b/src/osdep/amiberry_uaenet.cpp
@@ -58,21 +58,18 @@ struct uaenet_data {
 int log_ethernet;
 static int enumerated;
 static int ethernet_paused;
-static struct uaenet_data **uaenet_data;
-static int uaenet_count;
-static uae_sem_t queue_available;
 
-// Adds packet to outgoing queue
+// Adds received packet to incoming queue (called from worker thread)
 static void uaenet_queue(struct uaenet_data *ud, const uae_u8 *data, int len)
 {
     struct uaenet_queue *q;
 
     if (!ud || len <= 0 || len > MAX_PSIZE)
         return;
-    
+
     if (ud->packetsinbuffer > 10)
         return;
-    
+
     uae_sem_wait(&ud->queue_sem);
     
     q = xcalloc(struct uaenet_queue, 1);
@@ -89,7 +86,6 @@ static void uaenet_queue(struct uaenet_data *ud, const uae_u8 *data, int len)
     }
     ud->packetsinbuffer++;
     uae_sem_post(&ud->queue_sem);
-    uae_sem_post(&queue_available);
 }
 
 // Process packets in queue
@@ -132,9 +128,9 @@ static int uaenet_worker_thread(void *arg)
     uae_sem_post(&ud->sync_sem);
 
     while (ud->active2) {
-        // Process any received packets in the queue
-        while (uaenet_checkpacket(ud))
-            ;
+        // NOTE: received packet delivery (uaenet_checkpacket) is NOT done here.
+        // It is done on the emulation thread via uaenet_receive_poll() to avoid
+        // concurrent access to Am7990 chip state (csr[], boardram, interrupts).
 
         // Poll pcap for new packets (uses timeout from pcap_open_live)
         if (ud->handle) {
@@ -157,9 +153,7 @@ static void uaenet_close_driver_internal(struct uaenet_data *ud)
     
     ud->active = false;
     ud->active2 = false;
-    
-    uae_sem_post(&queue_available);
-    
+
     if (ud->tid) {
         write_log(_T("UAENET: Waiting for thread to terminate..\n"));
         uae_wait_thread(&ud->tid);
@@ -230,42 +224,97 @@ int uaenet_open(void *vsd, struct netdriverdata *ndd, void *userdata, ethernet_g
 {
     if (!enumerated)
         return 0;
-    
+
     struct uaenet_data *ud = (struct uaenet_data*)vsd;
     if (!ud)
         return 0;
-    
-    // Allocate new uaenet_data if needed
-    if (!uaenet_data) {
-        uaenet_count = 10;
-        uaenet_data = xcalloc(struct uaenet_data*, uaenet_count);
-        if (!uaenet_data)
-            return 0;
-        uae_sem_init(&queue_available, 0, 0);
+
+    // If already open (re-init), shut down existing thread and handle first
+    if (ud->active || ud->active2 || ud->handle) {
+        write_log(_T("UAENET: Re-opening '%s', shutting down existing state\n"), ndd->name);
+        ud->active = false;
+        ud->active2 = false;
+        if (ud->tid) {
+            uae_wait_thread(&ud->tid);
+            ud->tid = 0;
+        }
+        if (ud->handle) {
+            pcap_close(ud->handle);
+            ud->handle = NULL;
+        }
+        // Flush any queued packets
+        struct uaenet_queue *q = ud->first;
+        while (q) {
+            struct uaenet_queue *next = q->next;
+            xfree(q->data);
+            xfree(q);
+            q = next;
+        }
+        ud->first = ud->last = NULL;
+        ud->packetsinbuffer = 0;
     }
-    
+
     write_log(_T("UAENET: Opening '%s'\n"), ndd->name);
-    
+
     ud->mtu = MAX_MTU;
     ud->promiscuous = promiscuous;
     strncpy(ud->name, ndd->name, MAX_DPATH - 1);
     ud->name[MAX_DPATH - 1] = '\0';
-    
+
     if (mac)
         memcpy(ud->mac_addr, mac, 6);
-    
+
+    // Destroy existing semaphores before reinitializing to prevent value
+    // inflation — uae_sem_init() on an existing semaphore calls SDL_SemPost()
+    // instead of recreating, which inflates mutex values and breaks synchronization.
+    if (ud->change_sem) uae_sem_destroy(&ud->change_sem);
+    if (ud->sync_sem) uae_sem_destroy(&ud->sync_sem);
+    if (ud->queue_sem) uae_sem_destroy(&ud->queue_sem);
     uae_sem_init(&ud->change_sem, 0, 1);
     uae_sem_init(&ud->sync_sem, 0, 0);
     uae_sem_init(&ud->queue_sem, 0, 1);
-    
     // Open the device
-    ud->handle = pcap_open_live(ndd->name, 65536, promiscuous, 1, ud->errbuf);
+    // Always use promiscuous mode: on Linux bridge interfaces, the host
+    // interface (br0) has a different MAC than the emulated device. Without
+    // promiscuous mode, the kernel only delivers packets addressed to br0's
+    // own MAC — packets to the Amiga's MAC are silently discarded before
+    // reaching the pcap socket. The BPF filter already limits capture to
+    // relevant packets (to our MAC, broadcast, multicast).
+    ud->handle = pcap_open_live(ndd->name, 65536, 1, 1, ud->errbuf);
     if (!ud->handle) {
         write_log(_T("UAENET: Failed to open device: %s\n"), ud->errbuf);
         uaenet_close_driver_internal(ud);
         return 0;
     }
     
+    // BPF filter: accept packets destined to the Amiga's MAC, broadcast, or
+    // multicast — but reject packets sourced from the Amiga's own MAC.
+    // The source exclusion prevents transmit loopback (packets we send via
+    // pcap_sendpacket being immediately recaptured by pcap_next_ex).
+    // We do NOT use pcap_setdirection(PCAP_D_IN) because on Linux bridge
+    // interfaces, broadcast/multicast packets may be classified as "outgoing"
+    // by the kernel, causing them to be silently dropped.
+    if (mac) {
+        struct bpf_program fp;
+        char filter[256];
+        snprintf(filter, sizeof(filter),
+            "(ether dst %02x:%02x:%02x:%02x:%02x:%02x or ether broadcast or ether multicast)"
+            " and not ether src %02x:%02x:%02x:%02x:%02x:%02x",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+        write_log(_T("UAENET: BPF filter: %s\n"), filter);
+        if (pcap_compile(ud->handle, &fp, filter, 1, PCAP_NETMASK_UNKNOWN) == 0) {
+            if (pcap_setfilter(ud->handle, &fp) != 0) {
+                write_log(_T("UAENET: pcap_setfilter failed: %s (non-fatal)\n"),
+                          pcap_geterr(ud->handle));
+            }
+            pcap_freecode(&fp);
+        } else {
+            write_log(_T("UAENET: pcap_compile failed: %s (non-fatal)\n"),
+                      pcap_geterr(ud->handle));
+        }
+    }
+
     // Store the pointer to uaenet_data in the netdriverdata for later cleanup
     ndd->driverdata = ud;
 
@@ -273,7 +322,7 @@ int uaenet_open(void *vsd, struct netdriverdata *ndd, void *userdata, ethernet_g
     ud->getfunc = getfunc;
     ud->userdata = userdata;
     ud->active = true;
-    
+
     // Start worker thread
     uae_start_thread(_T("uaenet_pcap"), uaenet_worker_thread, ud, &ud->tid);
     uae_sem_wait(&ud->sync_sem);
@@ -299,26 +348,20 @@ void uaenet_close(void *vsd)
     struct uaenet_data *ud = (struct uaenet_data*)vsd;
     if (!ud)
         return;
-    
-    int i;
-    for (i = 0; i < uaenet_count; i++) {
-        if (uaenet_data && uaenet_data[i] == ud) {
-            uaenet_close_driver_internal(ud);
-            uaenet_data[i] = NULL;
-            
-            // Free any remaining queued packets
-            struct uaenet_queue *q = ud->first;
-            while (q) {
-                struct uaenet_queue *next = q->next;
-                xfree(q->data);
-                xfree(q);
-                q = next;
-            }
-            
-            xfree(ud);
-            break;
-        }
+
+    uaenet_close_driver_internal(ud);
+
+    // Free any remaining queued packets
+    struct uaenet_queue *q = ud->first;
+    while (q) {
+        struct uaenet_queue *next = q->next;
+        xfree(q->data);
+        xfree(q);
+        q = next;
     }
+    ud->first = ud->last = NULL;
+    ud->packetsinbuffer = 0;
+    // Note: do NOT xfree(ud) — the caller (a2065.cpp) owns the sysdata buffer
 }
 
 // Get MAC address of device
@@ -349,6 +392,16 @@ int uaenet_getmtu(void *vsd)
     return ud->mtu;
 }
 
+// Deliver queued received packets to the emulation — must be called from the emulation thread.
+void uaenet_receive_poll(void *vsd)
+{
+    struct uaenet_data *ud = (struct uaenet_data*)vsd;
+    if (!ud || !ud->active)
+        return;
+    while (uaenet_checkpacket(ud))
+        ;
+}
+
 // Get number of bytes pending
 int uaenet_getbytespending(void *vsd)
 {
@@ -366,15 +419,22 @@ int uaenet_getbytespending(void *vsd)
     return bytes;
 }
 
-// Trigger packet processing
+// Trigger packet transmission — called from ethernet_trigger() on the emulation thread
+// when the A2065 has a packet to send. Retrieves the packet via getfunc and sends
+// it directly via pcap_sendpacket.
 void uaenet_trigger(void *vsd)
 {
     struct uaenet_data *ud = (struct uaenet_data*)vsd;
-    if (!ud || !ud->active)
+    if (!ud || !ud->active || !ud->handle)
         return;
-    
-    // Signal that there might be data to process
-    uae_sem_post(&queue_available);
+
+    if (ud->getfunc) {
+        uae_u8 pkt[4000];
+        int len = sizeof pkt;
+        if (ud->getfunc(ud->userdata, pkt, &len)) {
+            pcap_sendpacket(ud->handle, (const u_char *)pkt, len);
+        }
+    }
 }
 
 // Free memory allocated during enumeration

--- a/src/osdep/amiberry_uaenet.h
+++ b/src/osdep/amiberry_uaenet.h
@@ -21,5 +21,6 @@ extern int uaenet_getbytespending (void*);
 extern int uaenet_open (void*, struct netdriverdata*, void*, uaenet_gotfunc*, uaenet_getfunc*, int, const uae_u8*);
 extern void uaenet_close (void*);
 extern void uaenet_trigger (void*);
+extern void uaenet_receive_poll (void*);
 
 #endif //AMIBERRY_UAENET_H


### PR DESCRIPTION
## Summary

The PCAP networking backend has five bugs that prevent the A2065 (Am7990 LANCE) emulation from working correctly, particularly on Linux bridge interfaces. With the worker thread deadlock (#1773) and config parsing (#1774) already fixed, these are the remaining issues needed to make PCAP bridged networking fully functional.

## The Problems

### 1. `uaenet_trigger()` never transmits

`uaenet_trigger()` is called by the A2065 emulation when the Am7990 has a packet to send. Instead of actually transmitting, it posts `queue_available` — a semaphore used for *receive* processing. No packet is ever retrieved from the transmit ring buffer or sent via pcap.

**Before:**
```
A2065 do_transmit() → ethernet_trigger() → uaenet_trigger()
  → uae_sem_post(&queue_available)  // signals receive path, not transmit
  → packet is never retrieved or sent
```

**Fix:** Rewrite `uaenet_trigger()` to call `getfunc()` (which retrieves the packet from the Am7990 transmit ring buffer) followed by `pcap_sendpacket()`.

### 2. `gotfunc()` called from wrong thread (race condition)

The worker thread called `uaenet_checkpacket()` → `gotfunc()` → `gotfunc2()`, which writes directly to Am7990 chip state (`csr[]`, `boardram[]`, interrupt registers). These are also accessed by the emulation thread with no synchronization, causing data corruption and missed interrupts.

**Fix:** Move packet delivery to the emulation thread. The worker thread now only queues received packets. A new `uaenet_receive_poll()` function, called from `a2065_hsync_handler()` on the emulation thread, dequeues and delivers them via `gotfunc()`. This follows the single-producer/single-consumer pattern — the worker thread produces (enqueues), the emulation thread consumes (dequeues and delivers).

### 3. `uaenet_close()` is a no-op

`uaenet_close()` searches `uaenet_data[]` for a matching pointer, but `uaenet_data[]` is never populated — `uaenet_open()` allocates the array but never stores anything in it. The loop finds no match, so the pcap handle and worker thread are leaked on every chip reinit.

**Before:**
```
uaenet_close(ud)
  → for (i = 0; i < uaenet_count; i++)
  →   if (uaenet_data[i] == ud)   // always false — array is all NULLs
  → nothing happens, handle and thread leaked
```

**Fix:** Call `uaenet_close_driver_internal()` directly. Remove the never-populated `uaenet_data[]` array, `uaenet_count`, and `queue_available` semaphore (dead code). Don't `xfree(ud)` — the caller (`a2065.cpp`) owns the `sysdata` buffer. Add a re-open guard in `uaenet_open()` that cleanly shuts down any existing state before reinitializing.

### 4. Non-promiscuous mode drops all unicast on bridge interfaces

`pcap_open_live()` was called with the `promiscuous` parameter from the caller, which is 0 for normal operation. On a Linux bridge interface, the bridge has its own MAC address (e.g., `de:91:f6:91:1a:eb`) which differs from the emulated NIC's MAC (`00:80:10:00:00:00`). Without promiscuous mode, the kernel only delivers frames addressed to the bridge's own MAC — unicast frames to the Amiga's MAC are silently discarded *before* reaching the pcap socket.

This bug was particularly difficult to diagnose because `tcpdump` temporarily enables promiscuous mode on the interface while it runs, so the emulated NIC would appear to work whenever diagnostic capture was active.

**Fix:** Always open pcap in promiscuous mode. The BPF filter (see below) already restricts capture to relevant packets, so promiscuous mode does not cause excessive CPU usage.

### 5. `pcap_setdirection(PCAP_D_IN)` drops broadcast/multicast on bridges

The original code used `pcap_setdirection(PCAP_D_IN)` to filter out transmitted packets. On Linux bridge interfaces, the kernel classifies broadcast and multicast frames as "outgoing" even when they arrive from the network, so `PCAP_D_IN` silently drops them all — ARP, DHCP, and any broadcast/multicast traffic never reaches the emulated NIC.

**Fix:** Replace `pcap_setdirection()` with a BPF source-exclusion filter:
```
(ether dst <amiga-mac> or ether broadcast or ether multicast)
and not ether src <amiga-mac>
```
This accepts all frames destined to the Amiga (unicast, broadcast, multicast) while rejecting transmit loopback, without relying on the kernel's direction classification.

### Bonus: Semaphore inflation on re-open

`uae_sem_init()` on an already-initialized semaphore calls `SDL_SemPost()` instead of recreating it. When `uaenet_open()` is called a second time (chip reinit), `queue_sem` goes from value 1 to 2, breaking its use as a mutex.

**Fix:** Call `uae_sem_destroy()` before `uae_sem_init()` on re-open.

## Files Changed

- **`src/osdep/amiberry_uaenet.cpp`** — All backend fixes: transmit rewrite, receive poll, close fix, re-open guard, semaphore fix, promiscuous mode, BPF filter, dead code removal
- **`src/a2065.cpp`** — Call `ethernet_receive_poll()` from `a2065_hsync_handler()` for thread-safe packet delivery
- **`src/ethernet.cpp`** — Add `ethernet_receive_poll()` dispatch function
- **`src/include/ethernet.h`** — Add `ethernet_receive_poll()` declaration
- **`src/osdep/amiberry_uaenet.h`** — Add `uaenet_receive_poll()` declaration

## Testing

Tested on Debian 13 (kernel 6.12) with an emulated A2065 NIC using PCAP on a Linux bridge interface (`br0`). The bridge connects the host to a VLAN where the Amiga gets a real IP via DHCP.

All tests pass:
- Ping gateway (192.168.6.1) — sustained, no drops
- Ping internet (8.8.8.8) — sustained, no drops
- DNS resolution — working
- FTP to ftp.aminet.net — directory listing and file download working (~8 KB/s, consistent with emulated Am7990 + AmigaOS TCP stack throughput)
- Reachable from other hosts on the network
- Survives Amiga reboot (chip reinit cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)