### PR TITLE
fix: segment GRO/GSO-coalesced packets in PCAP receive path

### DIFF
--- a/src/osdep/amiberry_uaenet.cpp
+++ b/src/osdep/amiberry_uaenet.cpp
@@ -17,9 +17,16 @@
 #include "sana2.h"
 #include "threaddep/thread.h"
 
-#define MAX_PSIZE 1600
 #define MAX_MTU 1500
-
+#ifndef ETH_HLEN
+#define ETH_HLEN 14
+#endif
+#ifndef ETH_P_IP
+#define ETH_P_IP 0x0800
+#endif
+#define IP_PROTO_TCP 6
+#define MAX_FRAME_LEN 1514    // Standard Ethernet frame without FCS
+#define MAX_GRO_SIZE 65536    // Max coalesced packet size from GRO/virtio
 
 // Forward declarations
 static int uaenet_worker_thread(void *arg);
@@ -59,19 +66,54 @@ int log_ethernet;
 static int enumerated;
 static int ethernet_paused;
 
-// Adds received packet to incoming queue (called from worker thread)
-static void uaenet_queue(struct uaenet_data *ud, const uae_u8 *data, int len)
+// Internet checksum (RFC 1071)
+static uae_u16 compute_ip_checksum(const uae_u8 *data, int len)
+{
+    uae_u32 sum = 0;
+    for (int i = 0; i < len - 1; i += 2)
+        sum += (data[i] << 8) | data[i + 1];
+    if (len & 1)
+        sum += data[len - 1] << 8;
+    while (sum >> 16)
+        sum = (sum & 0xffff) + (sum >> 16);
+    return (uae_u16)(~sum & 0xffff);
+}
+
+// TCP checksum with pseudo-header
+static uae_u16 compute_tcp_checksum(const uae_u8 *ip_hdr, int ip_hdr_len,
+    const uae_u8 *tcp_data, int tcp_len)
+{
+    uae_u32 sum = 0;
+    // Pseudo-header: src IP, dst IP, zero+protocol, TCP length
+    sum += (ip_hdr[12] << 8) | ip_hdr[13];
+    sum += (ip_hdr[14] << 8) | ip_hdr[15];
+    sum += (ip_hdr[16] << 8) | ip_hdr[17];
+    sum += (ip_hdr[18] << 8) | ip_hdr[19];
+    sum += IP_PROTO_TCP;
+    sum += tcp_len;
+    // TCP header + data
+    for (int i = 0; i < tcp_len - 1; i += 2)
+        sum += (tcp_data[i] << 8) | tcp_data[i + 1];
+    if (tcp_len & 1)
+        sum += tcp_data[tcp_len - 1] << 8;
+    while (sum >> 16)
+        sum = (sum & 0xffff) + (sum >> 16);
+    return (uae_u16)(~sum & 0xffff);
+}
+
+// Insert a single packet into the incoming queue (called from worker thread)
+static void uaenet_queue_one(struct uaenet_data *ud, const uae_u8 *data, int len)
 {
     struct uaenet_queue *q;
 
-    if (!ud || len <= 0 || len > MAX_PSIZE)
+    if (!ud || len <= 0 || len > MAX_FRAME_LEN)
         return;
 
-    if (ud->packetsinbuffer > 10)
+    if (ud->packetsinbuffer > 50)
         return;
 
     uae_sem_wait(&ud->queue_sem);
-    
+
     q = xcalloc(struct uaenet_queue, 1);
     q->data = xmalloc(uae_u8, len);
     memcpy(q->data, data, len);
@@ -86,6 +128,117 @@ static void uaenet_queue(struct uaenet_data *ud, const uae_u8 *data, int len)
     }
     ud->packetsinbuffer++;
     uae_sem_post(&ud->queue_sem);
+}
+
+// Segment GRO/GSO-coalesced IPv4/TCP packets into individual Ethernet frames.
+// Linux GRO, GSO, and virtio NICs can deliver TCP segments coalesced into packets
+// far larger than the Ethernet MTU. The A2065 emulation expects standard-sized
+// Ethernet frames, so we must split them back into individual segments here.
+static void uaenet_queue(struct uaenet_data *ud, const uae_u8 *data, int len)
+{
+    if (!ud || len <= 0 || len > MAX_GRO_SIZE)
+        return;
+
+    // Fast path: normal-sized frame, no segmentation needed
+    if (len <= MAX_FRAME_LEN) {
+        uaenet_queue_one(ud, data, len);
+        return;
+    }
+
+    // Oversized packet — check if it's IPv4/TCP that we can segment
+    if (len < ETH_HLEN + 20) // minimum Ethernet + IP header
+        return;
+
+    uae_u16 ethertype = (data[12] << 8) | data[13];
+    if (ethertype != ETH_P_IP) {
+        write_log(_T("UAENET: dropping oversized non-IPv4 packet (%d bytes, ethertype 0x%04x)\n"), len, ethertype);
+        return;
+    }
+
+    const uae_u8 *ip_hdr = data + ETH_HLEN;
+    int ip_version = (ip_hdr[0] >> 4) & 0xf;
+    int ip_hdr_len = (ip_hdr[0] & 0xf) * 4;
+    int ip_protocol = ip_hdr[9];
+
+    if (ip_version != 4 || ip_hdr_len < 20 || ip_protocol != IP_PROTO_TCP) {
+        write_log(_T("UAENET: dropping oversized non-TCP packet (%d bytes, proto %d)\n"), len, ip_protocol);
+        return;
+    }
+
+    if (len < ETH_HLEN + ip_hdr_len + 20) // minimum TCP header
+        return;
+
+    const uae_u8 *tcp_hdr = ip_hdr + ip_hdr_len;
+    int tcp_hdr_len = ((tcp_hdr[12] >> 4) & 0xf) * 4;
+    if (tcp_hdr_len < 20)
+        return;
+    int total_hdr_len = ETH_HLEN + ip_hdr_len + tcp_hdr_len;
+    int payload_len = len - total_hdr_len;
+    int mss = MAX_MTU - ip_hdr_len - tcp_hdr_len;
+    if (mss <= 0)
+        return;
+
+    uae_u32 orig_seq = ((uae_u32)tcp_hdr[4] << 24) | ((uae_u32)tcp_hdr[5] << 16) |
+                        ((uae_u32)tcp_hdr[6] << 8) | tcp_hdr[7];
+    uae_u16 orig_ip_id = (ip_hdr[4] << 8) | ip_hdr[5];
+    uae_u8 orig_tcp_flags = tcp_hdr[13];
+    const uae_u8 *payload = data + total_hdr_len;
+    int offset = 0;
+    int seg_num = 0;
+
+    while (offset < payload_len) {
+        int seg_payload = payload_len - offset;
+        if (seg_payload > mss)
+            seg_payload = mss;
+        bool last_segment = (offset + seg_payload >= payload_len);
+
+        uae_u8 seg[MAX_FRAME_LEN + 4];
+
+        // Ethernet header — unchanged
+        memcpy(seg, data, ETH_HLEN);
+
+        // IP header — update length, ID, checksum
+        memcpy(seg + ETH_HLEN, ip_hdr, ip_hdr_len);
+        uae_u8 *sip = seg + ETH_HLEN;
+        uae_u16 ip_total = ip_hdr_len + tcp_hdr_len + seg_payload;
+        sip[2] = (ip_total >> 8) & 0xff;
+        sip[3] = ip_total & 0xff;
+        uae_u16 new_ip_id = orig_ip_id + seg_num;
+        sip[4] = (new_ip_id >> 8) & 0xff;
+        sip[5] = new_ip_id & 0xff;
+        sip[10] = 0;
+        sip[11] = 0;
+        uae_u16 ip_ck = compute_ip_checksum(sip, ip_hdr_len);
+        sip[10] = (ip_ck >> 8) & 0xff;
+        sip[11] = ip_ck & 0xff;
+
+        // TCP header — update seq, flags, checksum
+        memcpy(seg + ETH_HLEN + ip_hdr_len, tcp_hdr, tcp_hdr_len);
+        uae_u8 *stcp = seg + ETH_HLEN + ip_hdr_len;
+        uae_u32 new_seq = orig_seq + offset;
+        stcp[4] = (new_seq >> 24) & 0xff;
+        stcp[5] = (new_seq >> 16) & 0xff;
+        stcp[6] = (new_seq >> 8) & 0xff;
+        stcp[7] = new_seq & 0xff;
+        // FIN and PSH only on last segment
+        if (!last_segment)
+            stcp[13] = orig_tcp_flags & ~0x09; // clear FIN(0x01) and PSH(0x08)
+        else
+            stcp[13] = orig_tcp_flags;
+        // Clear checksum, copy payload, recompute
+        stcp[16] = 0;
+        stcp[17] = 0;
+        memcpy(seg + total_hdr_len, payload + offset, seg_payload);
+        int tcp_total = tcp_hdr_len + seg_payload;
+        uae_u16 tcp_ck = compute_tcp_checksum(sip, ip_hdr_len, stcp, tcp_total);
+        stcp[16] = (tcp_ck >> 8) & 0xff;
+        stcp[17] = tcp_ck & 0xff;
+
+        uaenet_queue_one(ud, seg, ETH_HLEN + ip_total);
+
+        offset += seg_payload;
+        seg_num++;
+    }
 }
 
 // Process packets in queue


### PR DESCRIPTION
## Summary

PCAP bridged networking delivers ~3-7 KB/s throughput on hosts with GRO, GSO, or virtio NICs — roughly 100x slower than real A2065 hardware. This PR fixes the root cause and restores expected throughput.

## The Problem

Linux GRO (Generic Receive Offload), GSO, and virtio mergeable receive buffers coalesce multiple TCP segments into single oversized packets before delivering them to pcap sockets. A burst of 10 standard 1460-byte TCP segments arrives as a single 14,600-byte packet.

The PCAP backend had a hard-coded 1600-byte receive limit (`MAX_PSIZE`):

```c
#define MAX_PSIZE 1600

static void uaenet_queue(struct uaenet_data *ud, const uae_u8 *data, int len)
{
    if (!ud || len <= 0 || len > MAX_PSIZE)
        return;  // silently dropped
```

Every coalesced packet was silently dropped. The only packets that survived were single-segment retransmissions (1460 bytes) triggered after the TCP sender's retransmission timeout expired — typically 300ms on LAN, 500ms+ for remote servers. This forced TCP into a degenerate one-segment-per-RTO-cycle mode:

```
1460 bytes / 300ms = ~4.9 KB/s (LAN)
1460 bytes / 500ms = ~2.9 KB/s (remote)
```

Disabling GRO/GSO/TSO via `ethtool` does not help on virtualized hosts (Proxmox/KVM, Hyper-V, etc.) because the hypervisor coalesces packets in the virtual NIC before the guest kernel sees them.

## The Fix

Replace the hard drop with TCP segmentation. When the PCAP backend receives a packet larger than a standard Ethernet frame (1514 bytes):

1. **Fast path**: Packets <= 1514 bytes pass through directly (zero overhead for normal traffic)
2. **Oversized IPv4/TCP**: Parse Ethernet, IP, and TCP headers, then segment the payload into MSS-sized chunks. For each segment, build a complete Ethernet frame with updated IP header (length, identification, checksum), TCP header (sequence number, flags, checksum), and payload
3. **Non-IPv4/non-TCP oversized**: Log and drop (GRO only coalesces TCP in practice)

Per-segment details:
- **IP identification**: incremented per segment
- **TCP sequence number**: advanced by payload offset
- **TCP flags**: FIN and PSH preserved only on the final segment
- **Checksums**: both IP header and TCP (with pseudo-header) fully recomputed

The receive queue depth is also raised from 10 to 50. A single GRO-coalesced packet segments into 10+ frames, so the old limit would drop most segments from a single burst.

## Testing

Tested on Debian 13 (kernel 6.12) running as a Proxmox VM with a virtio NIC. Emulated A4000/040 with A2065 NIC, Roadshow TCP/IP stack. GRO/GSO/TSO left enabled at default settings.

**LAN FTP (200KB file):**
- Before: 204,800 bytes in 31 seconds (~6.6 KB/s)
- After: 204,800 bytes in 0.226 seconds (~885 KB/s) — **134x improvement**

**Remote FTP (Aminet, transatlantic):**
- Before: 202,765 bytes in 63.4 seconds (~3.2 KB/s)
- After: 202,765 bytes in 3.37 seconds (~60 KB/s) — **19x improvement**

The LAN result (885 KB/s) exceeds real A4000/040 + A2065 benchmarks (400-600 KB/s), which is expected since the emulated 68040 runs at an effective clock speed higher than 25 MHz. The remote result (60 KB/s) is RTT-bound, consistent with Roadshow's 33KB TCP window over a ~170ms path.

Generated with [Claude Code](https://claude.com/claude-code)