### PR TITLE
Make F12 start emulation again

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1230,6 +1230,15 @@ void run_gui()
 					uae_quit();
 					gui_running = false;
 				}
+				else if (gui_event.key.keysym.sym == SDLK_F12 && !start_disabled) {
+					if (emulating) {
+						gui_running = false;
+					}
+					else {
+						uae_reset(0, 1);
+						gui_running = false;
+					}
+				}
 			}
 			else if (gui_event.type == SDL_DROPFILE) {
 				// Handle dropped files


### PR DESCRIPTION
Seems like it got lost when switching over to Imgui

@midwan
