### PR TITLE
doc: add quick links to the latest release on github

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,7 +92,7 @@ brew install --cask amiberry
 Amiberry supports Windows x86_64 using MinGW-w64 (GCC).
 
 **Releases:**
-1.  Download the latest `.zip` from [Releases](https://github.com/BlitterStudio/amiberry/releases).
+1.  Download the latest `.zip` from [Releases](https://github.com/BlitterStudio/amiberry/releases/latest).
 2.  Extract the contents to a directory of your choice.
 3.  Run `Amiberry.exe` to start the emulator.
 


### PR DESCRIPTION
Added a quick link to the latest release on GitHub in the Linux section and updated the macOS releases link to point to the latest release.

@midwan
