### PR TITLE
Remove duplicate source file entry for shuf.cpp

### DIFF
--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -184,7 +184,6 @@ set(SOURCE_FILES
         src/archivers/lha/lhamaketbl.cpp
         src/archivers/lha/lharc.cpp
         src/archivers/lha/shuf.cpp
-        src/archivers/lha/shuf.cpp
         src/archivers/lha/slide.cpp
         src/archivers/lha/uae_lha.cpp
         src/archivers/lha/util.cpp


### PR DESCRIPTION
Removed duplicate entry for 'shuf.cpp' in the source files list.

