### PR TITLE
Add x86-64 JIT PIE compatibility implementation plan

### DIFF
--- a/docs/x86-64-jit-pie-plan/README.md
+++ b/docs/x86-64-jit-pie-plan/README.md
@@ -1,0 +1,57 @@
+# x86-64 JIT PIE Compatibility Plan
+
+## Problem
+
+The x86-64 JIT currently requires `-fno-pie` because it uses RIP-relative
+`[RIP+disp32]` addressing (via the `_r_X` macro in `codegen_x86.h`) for global
+variable access. This requires JIT code to be within ±2GB of `.data`. Non-PIE
+builds satisfy this by placing `.data` at fixed low addresses, but PIE+ASLR
+randomizes `.data` placement.
+
+**Key insight:** RIP-relative addressing is the *standard* x86-64 mode — it's
+not anti-PIE. We just need to guarantee JIT code allocation stays within ±2GB
+of `.data`. The Windows port already does this via a VirtualQuery-based anchor
+allocator. We extend this to Linux.
+
+## Phases (execute in order)
+
+| Phase | File | Summary |
+|-------|------|---------|
+| 1 | [phase-1-fix-branch-truncation.md](phase-1-fix-branch-truncation.md) | Fix 32-bit pointer truncation in conditional branch emitters |
+| 2 | [phase-2-fix-veccode-allocation.md](phase-2-fix-veccode-allocation.md) | Change veccode allocation from MAP_32BIT to anchor-based |
+| 3 | [phase-3-harden-probe-loop.md](phase-3-harden-probe-loop.md) | Harden vm_acquire probe loop for PIE+ASLR reliability |
+| 4 | [phase-4-add-distance-diagnostic.md](phase-4-add-distance-diagnostic.md) | Add runtime proximity check between JIT cache and globals |
+| 5 | [phase-5-remove-pie-guard-and-flags.md](phase-5-remove-pie-guard-and-flags.md) | Remove #error guard and -fno-pie flags |
+| 6 | [phase-6-update-comments.md](phase-6-update-comments.md) | Update comments explaining constraints |
+
+## What stays unchanged (and why)
+
+| Component | Reason |
+|-----------|--------|
+| `_r_X` RIP-relative macro | Works fine — anchor strategy guarantees proximity |
+| R_MEMSTART (R15) register-indirect | Already PIE-safe |
+| PC_P 64-bit handling | Already fully 64-bit in register allocator |
+| natmem UAE_VM_32BIT | comp_pc_p and other 32-bit arithmetic depend on low-4GB natmem |
+| isconst guards | Already correctly disabled on x86-64 |
+| Function calls/jumps | Already use movabs+indirect (PIE-safe) |
+| FreeBSD ADDR32 path | Keeps -fno-pie; PIE would require removing ADDR32 (separate project) |
+
+## Verification (after all phases)
+
+1. **Build as PIE:** `cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j$(nproc)`, then `readelf -h build/amiberry | grep Type` → should show `DYN`
+2. **JIT functional test:** Boot A1200 with JIT (cachesize=8192), run WorkBench
+3. **Check diagnostics:** Run with `--log`, verify no distance warnings
+4. **FPU test:** Run FPU-heavy software (triggers comp_pc_p assert path)
+5. **Non-PIE regression:** Build with explicit `-fno-pie` to verify it still works
+6. **FreeBSD:** Verify FreeBSD build still gets `-fno-pie` from CMake
+
+## Key files reference
+
+| File | Role |
+|------|------|
+| `src/jit/x86/codegen_x86.cpp` | Instruction emitters (branch functions) |
+| `src/jit/x86/codegen_x86.h` | `_r_X` macro (RIP-relative addressing) |
+| `src/jit/x86/compemu_support_x86.cpp` | JIT cache allocation, anchor probe loop, #error guard |
+| `src/jit/x86/exception_handler.cpp` | veccode trampoline allocation |
+| `src/jit/x86/compemu_fpp_x86.cpp` | FPU JIT, comp_pc_p assert |
+| `cmake/SourceFiles.cmake` | -fno-pie/-no-pie flags |

--- a/docs/x86-64-jit-pie-plan/phase-1-fix-branch-truncation.md
+++ b/docs/x86-64-jit-pie-plan/phase-1-fix-branch-truncation.md
@@ -1,0 +1,76 @@
+# Phase 1: Fix Conditional Branch Offset Truncation
+
+## Priority: HIGH (correctness bug)
+
+## Problem
+
+In `src/jit/x86/codegen_x86.cpp`, the conditional branch emitters (`raw_jl`,
+`raw_jz`, `raw_jnz`, etc.) truncate the code pointer to 32 bits before
+computing the relative displacement:
+
+```c
+static inline void raw_jl(uae_u32 t)
+{
+    raw_jcc_l_oponly(NATIVE_CC_LT);
+    emit_long(t - (uae_u32)JITPTR target - 4);
+}
+```
+
+The `(uae_u32)JITPTR target` cast truncates the current emit position to 32
+bits. Under PIE+ASLR, JIT code could be above 4GB, producing wrong
+displacements. The parameter `t` is also `uae_u32`, truncating the target.
+
+**Note:** Under non-PIE this works because JIT memory is allocated in low 4GB
+via MAP_32BIT. Under PIE, the anchor-based allocator places JIT memory near
+`.data` which could be anywhere in the 47-bit VA space.
+
+## Files to modify
+
+- `src/jit/x86/codegen_x86.cpp` (lines ~1381-1397)
+
+## Changes
+
+Find all `raw_j*` functions that follow this pattern:
+
+```c
+static inline void raw_jl(uae_u32 t)
+{
+    raw_jcc_l_oponly(NATIVE_CC_LT);
+    emit_long(t - (uae_u32)JITPTR target - 4);
+}
+```
+
+Change each to use `uintptr` for the parameter type and pointer arithmetic:
+
+```c
+static inline void raw_jl(uintptr t)
+{
+    raw_jcc_l_oponly(NATIVE_CC_LT);
+    emit_long((uae_u32)(t - (uintptr)target - 4));
+}
+```
+
+**Key principle:** Do the subtraction at full pointer width (both operands are
+in the same JIT block, so the difference is small), then truncate the *result*
+to 32 bits for the x86 rel32 encoding.
+
+### Functions to fix (search for `raw_jcc_l_oponly` and `raw_jmp_l_oponly` callers)
+
+Grep for all functions matching the pattern. Expected functions include:
+- `raw_jl`
+- `raw_jz`
+- `raw_jnz`
+- `raw_jnl`  (if exists)
+- `raw_jge`  (if exists)
+- Any other `raw_j*` variants
+
+Also check `raw_jmp` if it has a similar pattern.
+
+## Verification
+
+After this change:
+- The code should compile cleanly with no warnings about integer truncation
+- Grep for `(uae_u32)JITPTR target` — there should be no remaining instances
+  in branch-related functions
+- The relative displacement computation is now correct regardless of where in
+  the address space the JIT code lives

--- a/docs/x86-64-jit-pie-plan/phase-2-fix-veccode-allocation.md
+++ b/docs/x86-64-jit-pie-plan/phase-2-fix-veccode-allocation.md
@@ -1,0 +1,99 @@
+# Phase 2: Fix veccode Allocation Strategy
+
+## Priority: HIGH (required for PIE)
+
+## Problem
+
+In `src/jit/x86/exception_handler.cpp`, the veccode trampoline is allocated
+with `UAE_VM_32BIT` (maps to `MAP_32BIT` on Linux), forcing it into the low
+2GB:
+
+```c
+veccode = (uae_u8 *) uae_vm_alloc(256, UAE_VM_32BIT, UAE_VM_READ_WRITE_EXECUTE);
+```
+
+The veccode trampoline generates RIP-relative references to globals (e.g.,
+`regs`, exception handler pointers). Under PIE, globals are not in the low 2GB,
+so veccode must be placed near `.data` instead of in the low 2GB.
+
+## Files to modify
+
+- `src/jit/x86/exception_handler.cpp` (~line 890)
+
+## Approach
+
+Replace the `UAE_VM_32BIT` allocation with the anchor-based allocation strategy
+already used by the JIT cache allocator in `compemu_support_x86.cpp`.
+
+### Option A: Use vm_acquire from compemu_support_x86.cpp
+
+The function `vm_acquire` in `compemu_support_x86.cpp` (lines ~210-269)
+already implements a probe loop that allocates memory within ±1.75GB of a
+`.data` anchor. If this function can be exposed (declare in a header or make
+non-static), veccode can use it:
+
+```c
+// In exception_handler.cpp
+veccode = (uae_u8 *) vm_acquire(256, UAE_VM_READ_WRITE_EXECUTE);
+```
+
+### Option B: Allocate veccode from the JIT cache region
+
+Since veccode is only 256 bytes, it could be carved from the beginning or end
+of the JIT cache allocation (which is already correctly placed by the anchor
+allocator). This avoids needing a separate allocation.
+
+### Option C: Inline the probe logic
+
+If neither Option A nor B is feasible, inline a small version of the probe loop:
+
+```c
+static uae_u8 data_anchor_eh;
+
+static void *alloc_near_data(size_t size, int prot)
+{
+    uintptr_t anchor = (uintptr_t)&data_anchor_eh;
+    for (intptr_t offset = 0; offset < 0x70000000; offset += 0x200000) {
+        for (int sign = 1; sign >= -1; sign -= 2) {
+            uintptr_t try_addr = anchor + sign * offset;
+            try_addr &= ~(uintptr_t)0xFFF; // page-align
+            void *p = mmap((void *)try_addr, size, prot,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            if (p != MAP_FAILED) {
+                intptr_t dist = (intptr_t)p - (intptr_t)anchor;
+                if (llabs(dist) < 0x70000000)
+                    return p;
+                munmap(p, size);
+            }
+        }
+    }
+    return NULL;
+}
+```
+
+### Recommended: Option A
+
+Option A is cleanest. Steps:
+1. In `compemu_support_x86.cpp`, remove `static` from `vm_acquire` (or rename
+   to `jit_vm_acquire` to avoid naming conflicts)
+2. Declare it in a header (e.g., `compemu_support_x86.h` or a new
+   `jit_alloc.h`)
+3. In `exception_handler.cpp`, call it instead of `uae_vm_alloc`
+
+## Timing concern
+
+`veccode` is allocated in `exception_handler.cpp` (likely during early JIT
+init). The anchor allocator in `compemu_support_x86.cpp` is also used during
+JIT init. Verify that veccode allocation happens at a point where the anchor
+strategy is available. If veccode is allocated before the JIT cache, the anchor
+variable still works (it's a static global — always at its final address).
+
+## Verification
+
+- Verify veccode is allocated near globals: add a log line:
+  ```c
+  write_log("veccode=%p regs=%p dist=%lld\n", veccode, &regs,
+            (long long)((intptr_t)veccode - (intptr_t)&regs));
+  ```
+- Distance should be well under 2GB
+- Run with JIT enabled, trigger exception paths (access unmapped Amiga memory)

--- a/docs/x86-64-jit-pie-plan/phase-3-harden-probe-loop.md
+++ b/docs/x86-64-jit-pie-plan/phase-3-harden-probe-loop.md
@@ -1,0 +1,87 @@
+# Phase 3: Harden vm_acquire Probe Loop
+
+## Priority: MEDIUM (reliability under hardened kernels)
+
+## Problem
+
+The existing probe loop in `compemu_support_x86.cpp` (lines ~210-269) uses
+`mmap` with address hints to place JIT memory within ±1.75GB of `.data`. Under
+standard kernels this works well, but:
+
+1. Some hardened kernels may ignore mmap hints more aggressively
+2. Without `MAP_FIXED_NOREPLACE`, mmap can silently place the allocation at a
+   completely different address (the hint is just a hint)
+3. The current code checks distance after the fact, but the fallback at line
+   265-268 uses `uae_vm_alloc(size, 0, ...)` which gets OS-chosen placement
+   that could be far away
+
+## Files to modify
+
+- `src/jit/x86/compemu_support_x86.cpp` (~lines 210-269)
+
+## Changes
+
+### 3a: Use MAP_FIXED_NOREPLACE when available
+
+In the probe loop's `mmap` call, add `MAP_FIXED_NOREPLACE` (Linux 4.17+).
+With this flag, `mmap` either places at the exact requested address or returns
+`MAP_FAILED` (never silently relocates):
+
+```c
+#ifdef MAP_FIXED_NOREPLACE
+    int extra_flags = MAP_FIXED_NOREPLACE;
+#else
+    int extra_flags = 0;
+#endif
+
+    result = mmap((void *)try_addr, size, PROT_READ | PROT_WRITE,
+        MAP_PRIVATE | MAP_ANONYMOUS | extra_flags, -1, 0);
+```
+
+When `MAP_FIXED_NOREPLACE` is available, the distance check after mmap is
+technically redundant but should be kept as a safety net.
+
+When `MAP_FIXED_NOREPLACE` is not available (older kernels, macOS, FreeBSD),
+the existing behavior (hint + distance check) remains.
+
+### 3b: Improve fallback error handling
+
+The fallback at the end of the probe loop currently does:
+
+```c
+result = uae_vm_alloc(size, 0, UAE_VM_READ_WRITE);
+```
+
+This can place memory anywhere. Add a distance check after this fallback:
+
+```c
+result = uae_vm_alloc(size, 0, UAE_VM_READ_WRITE);
+if (result) {
+    intptr_t dist = (intptr_t)result - (intptr_t)&data_anchor;
+    if (llabs(dist) >= 0x70000000) {
+        write_log("JIT: FATAL: could not allocate cache within 2GB of globals "
+                   "(cache=%p anchor=%p dist=%lld)\n",
+                   result, &data_anchor, (long long)dist);
+        uae_vm_free(result, size);
+        result = NULL;
+        // JIT will be disabled (cachesize = 0)
+    }
+}
+```
+
+### 3c: Log the successful allocation
+
+After a successful allocation with acceptable distance, log it:
+
+```c
+write_log("JIT: cache allocated at %p (anchor=%p, dist=%+lld)\n",
+          result, &data_anchor, (long long)((intptr_t)result - (intptr_t)&data_anchor));
+```
+
+## Verification
+
+- Build and run on a stock Linux kernel: probe loop should succeed on first or
+  second attempt
+- Check `--log` output for the allocation address and distance
+- Distance should be well under 1.75GB (0x70000000)
+- On older kernels without `MAP_FIXED_NOREPLACE`, behavior should be unchanged

--- a/docs/x86-64-jit-pie-plan/phase-4-add-distance-diagnostic.md
+++ b/docs/x86-64-jit-pie-plan/phase-4-add-distance-diagnostic.md
@@ -1,0 +1,45 @@
+# Phase 4: Add Runtime Distance Diagnostic
+
+## Priority: LOW (diagnostic / safety net)
+
+## Problem
+
+If the JIT cache is accidentally placed too far from globals, the result is
+silent corruption (wrong RIP-relative offsets). A runtime diagnostic provides
+early detection.
+
+## Files to modify
+
+- `src/jit/x86/compemu_support_x86.cpp` (in `alloc_cache` or `build_comp`,
+  after `compiled_code` / JIT cache is allocated)
+
+## Changes
+
+After the JIT cache allocation succeeds, add a proximity check:
+
+```c
+// Verify JIT cache is within RIP-relative reach of globals
+{
+    intptr_t dist = (intptr_t)compiled_code - (intptr_t)&regs;
+    write_log("JIT: code cache at %p, regs at %p, distance=%+lld bytes\n",
+              compiled_code, &regs, (long long)dist);
+    if (llabs(dist) > (intptr_t)0x70000000) {
+        write_log("JIT: WARNING: code cache is %lld bytes from globals — "
+                  "RIP-relative addressing may fail! Disabling JIT.\n",
+                  (long long)dist);
+        // Disable JIT to prevent silent corruption
+        changed_prefs.cachesize = 0;
+        currprefs.cachesize = 0;
+    }
+}
+```
+
+This uses `regs` as the reference point because it's the most frequently
+accessed global via `_r_X` RIP-relative addressing.
+
+## Verification
+
+- Run with `--log` and verify the distance is printed
+- On a normal PIE build, distance should be well under 1.75GB
+- If you want to test the warning path, you could temporarily hack the
+  threshold to a very small value

--- a/docs/x86-64-jit-pie-plan/phase-5-remove-pie-guard-and-flags.md
+++ b/docs/x86-64-jit-pie-plan/phase-5-remove-pie-guard-and-flags.md
@@ -1,0 +1,77 @@
+# Phase 5: Remove #error Guard and -fno-pie Flags
+
+## Priority: HIGH (the actual user-facing change)
+
+## Prerequisites
+
+Phases 1-4 must be completed first. This phase removes the safety guards that
+prevent PIE builds, so the fixes from earlier phases must be in place.
+
+## Files to modify
+
+1. `src/jit/x86/compemu_support_x86.cpp` (lines 106-108)
+2. `cmake/SourceFiles.cmake` (line ~563)
+
+## Changes
+
+### 5a: Remove compile-time #error guard
+
+In `src/jit/x86/compemu_support_x86.cpp`, find and remove:
+
+```c
+#if defined(__pie__) || defined(__PIE__)
+#error Position-independent code (PIE) cannot be used with JIT
+#endif
+```
+
+### 5b: Update CMake flags
+
+In `cmake/SourceFiles.cmake`, find the block (around line 563):
+
+```cmake
+if(NOT ANDROID AND NOT WIN32)
+    target_compile_options(${PROJECT_NAME} PRIVATE -fno-pie)
+    target_link_options(${PROJECT_NAME} PRIVATE -no-pie)
+```
+
+Replace with:
+
+```cmake
+if(NOT ANDROID AND NOT WIN32
+        AND CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
+        AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+    # FreeBSD x86-64 JIT uses ADDR32 prefix + MAP_32BIT strategy,
+    # requiring all code/data in the low 2GB. PIE would break this.
+    # Linux/macOS x86-64 use RIP-relative + anchor-based allocation,
+    # which is PIE-compatible.
+    target_compile_options(${PROJECT_NAME} PRIVATE -fno-pie)
+    target_link_options(${PROJECT_NAME} PRIVATE -no-pie)
+```
+
+This keeps `-fno-pie` only for FreeBSD x86-64 (which uses the fundamentally
+different ADDR32+MAP_32BIT approach that is incompatible with PIE).
+
+All other platforms — Linux x86-64, macOS x86-64, ARM64 everywhere — will
+now build as PIE by default.
+
+## Verification
+
+1. **Linux x86-64:** Build and check binary type:
+   ```bash
+   cmake -B build -DCMAKE_BUILD_TYPE=Release
+   cmake --build build -j$(nproc)
+   readelf -h build/amiberry | grep Type
+   # Should show: Type: DYN (Position-Independent Executable)
+   ```
+
+2. **Non-PIE regression:** Verify explicit non-PIE still works:
+   ```bash
+   cmake -B build-nopie -DCMAKE_BUILD_TYPE=Release \
+     -DCMAKE_C_FLAGS="-fno-pie" -DCMAKE_CXX_FLAGS="-fno-pie" \
+     -DCMAKE_EXE_LINKER_FLAGS="-no-pie"
+   cmake --build build-nopie -j$(nproc)
+   ```
+
+3. **ARM64:** Verify ARM64 build is unaffected (no `-fno-pie` was needed)
+
+4. **JIT functional:** Boot A1200 with JIT enabled, run software

--- a/docs/x86-64-jit-pie-plan/phase-6-update-comments.md
+++ b/docs/x86-64-jit-pie-plan/phase-6-update-comments.md
@@ -1,0 +1,63 @@
+# Phase 6: Update Comments
+
+## Priority: LOW (documentation only)
+
+## Files to modify
+
+- `src/jit/x86/compemu_fpp_x86.cpp` (line ~738)
+- `src/jit/x86/compemu_support_x86.cpp` (near the removed #error, and near
+  the anchor allocator)
+
+## Changes
+
+### 6a: comp_pc_p assert comment
+
+In `src/jit/x86/compemu_fpp_x86.cpp`, find the assert around line 738-739:
+
+```c
+assert((uintptr) comp_pc_p <= 0xffffffffUL);
+```
+
+Add or update the comment above it to clarify the constraint:
+
+```c
+// comp_pc_p points into natmem, which is allocated with UAE_VM_32BIT
+// (low 4GB) on x86-64. This is independent of PIE/ASLR — natmem
+// placement uses explicit mmap hints, not .text/.data ASLR.
+assert((uintptr) comp_pc_p <= 0xffffffffUL);
+```
+
+### 6b: Anchor allocator documentation
+
+In `src/jit/x86/compemu_support_x86.cpp`, near the `data_anchor` variable and
+`vm_acquire` function, add a block comment explaining the PIE strategy:
+
+```c
+/*
+ * JIT cache allocation strategy (PIE-compatible):
+ *
+ * x86-64 JIT uses RIP-relative [RIP+disp32] addressing to access globals
+ * (regs, regflags, etc.) via the _r_X() macro. This requires the JIT code
+ * cache to be within ±2GB of .data.
+ *
+ * Under non-PIE, .data is at a fixed low address and MAP_32BIT suffices.
+ * Under PIE+ASLR, .data can be anywhere in the 47-bit VA space.
+ *
+ * We use an anchor-based probe: &data_anchor is a reference point in .data,
+ * and we search outward from it for a free VA range. This mirrors the
+ * Windows strategy (VirtualQuery walk from data_anchor).
+ *
+ * The probe covers ±1.75GB at 2MB intervals, well within the ±2GB
+ * RIP-relative limit.
+ */
+```
+
+### 6c: FreeBSD comment in CMake
+
+If not already added in Phase 5, ensure the CMake condition for FreeBSD
+has a clear comment explaining why FreeBSD is the exception.
+
+## Verification
+
+- Review comments make sense and accurately describe the design
+- No functional changes in this phase — build should be identical


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Add comprehensive 6-phase implementation plan for making x86-64 JIT compatible with Position-Independent Executables (PIE)
- Document the core issue: JIT code uses RIP-relative addressing requiring proximity to `.data`, which conflicts with PIE+ASLR
- Provide detailed specifications for fixing branch offset truncation, veccode allocation, probe loop hardening, and runtime diagnostics
- Include verification steps and rationale for each phase

## Summary

This PR adds planning documentation for enabling PIE support on x86-64 JIT builds. The plan consists of 6 phases:

1. **Phase 1**: Fix 32-bit pointer truncation in conditional branch emitters (`raw_jl`, `raw_jz`, etc.) that incorrectly cast pointers to `uae_u32`
2. **Phase 2**: Replace `MAP_32BIT` allocation strategy for veccode trampoline with anchor-based allocation (similar to JIT cache)
3. **Phase 3**: Harden the `vm_acquire` probe loop with `MAP_FIXED_NOREPLACE` and improved fallback error handling
4. **Phase 4**: Add runtime distance diagnostic to detect if JIT cache drifts too far from globals
5. **Phase 5**: Remove the `#error` guard and `-fno-pie` compiler flags (except FreeBSD which uses incompatible ADDR32 strategy)
6. **Phase 6**: Update comments explaining the PIE-compatible design

The key insight is that RIP-relative addressing (the standard x86-64 mode) is not inherently anti-PIE—we just need to guarantee JIT code allocation stays within ±2GB of `.data`. The Windows port already implements this via anchor-based allocation; this plan extends it to Linux/macOS.

## Test Plan

N/A - This is planning documentation only. Implementation will follow in subsequent PRs with corresponding code changes and testing.

https://claude.ai/code/session_014qSPWviZVk9VheJF5173u7