### PR TITLE
fix: correct JIT cache distance check threshold to actual RIP-relativ…

### DIFF
--- a/src/jit/x86/compemu_support_x86.cpp
+++ b/src/jit/x86/compemu_support_x86.cpp
@@ -4052,7 +4052,7 @@ void alloc_cache(void)
 			intptr_t dist = (intptr_t)compiled_code - (intptr_t)&regs;
 			jit_log("code cache at %p, regs at %p, distance=%+lld bytes",
 				compiled_code, (void *)&regs, (long long)dist);
-			if (llabs(dist) > (intptr_t)0x70000000) {
+			if (llabs(dist) > (intptr_t)0x7F000000) {
 				jit_log("WARNING: code cache is %+lld bytes from globals -- "
 					"RIP-relative addressing may fail! Disabling JIT.",
 					(long long)dist);


### PR DESCRIPTION
## Summary

The distance check introduced in bf1a6a52 uses `0x70000000` (1.75GB) as
the threshold for disabling JIT when the cache is too far from globals.
This value matches the hint loop search range but not the actual x86-64
RIP-relative hardware limit of `0x7FFFFFFF` (2GB), causing JIT to be
incorrectly disabled on platforms where the cache legitimately lands
between 1.75GB and 2GB from globals.

## Root Cause

The code supports two distinct JIT cache placement strategies:

1. **Anchor-based hint loop** (Linux/macOS/Windows PIE): probes outward
   from `data_anchor` at 2MB intervals within ±1.75GB, placing the cache
   near `.data`.

2. **MAP_32BIT + ADDR32** (FreeBSD non-PIE, as noted in the comment at
   line 108): forces the cache below 2GB via `MAP_32BIT`, using the
   `0x67` address-size prefix for absolute 32-bit addressing.

For strategy 2, the cache can land anywhere below 2GB regardless of
where `.data` is. On FreeBSD 15 x86-64 with globals at `~0x5046dc8`,
`MAP_32BIT` places the cache at `~0x7de98000` — a distance of **1.888GB**,
valid for RIP-relative encoding but rejected by the `0x70000000` check:
```
JIT: code cache at 0x7de98000, regs at 0x5046dc8, distance=+2028278328 bytes
JIT: WARNING: code cache is +2028278328 bytes from globals -- RIP-relative addressing may fail! Disabling JIT.
```

The result is a silent JIT disable — the emulator boots but renders a
black screen with no error messages beyond the log warning.

## Fix

Change the threshold from `0x70000000` to `0x7F000000`, reflecting the
actual x86-64 hardware RIP-relative limit with a small safety margin for
instruction length. The hint loop search range (`0x70000000`) is
unchanged — it is a placement tuning parameter, not a hardware
constraint, and these two values should never have been conflated.

## Testing

Tested on FreeBSD 15 x86-64 with `kern.elf64.aslr.enable=1`. JIT cache
at `0x7de98000`, globals at `0x5046dc8`, distance 1.888GB — JIT now
enables correctly and Workbench boots fully.

This fix is ungated (applies to all platforms) because the threshold is
objectively wrong for any platform using strategy 2, and future-proofs
against any other platform where `MAP_32BIT` or an equivalent strategy
places the cache above 1.75GB from globals.

## Related

Follows up on #1814 (FreeBSD JIT support) and bf1a6a52 (PIE
compatibility refactor).