### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -1,5 +1,8 @@
 name: Upload to Launchpad PPA
 
+permissions:
+  contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
Potential fix for [https://github.com/BlitterStudio/amiberry/security/code-scanning/28](https://github.com/BlitterStudio/amiberry/security/code-scanning/28)

To fix the issue, we should explicitly declare the minimal required permissions for the workflow or for the specific job. This workflow only needs to read the repository contents (for `actions/checkout` and copying the source tree) and does not interact with pull requests, issues, or perform writes back to the repository. Therefore, setting `contents: read` at the workflow root is sufficient and follows the least-privilege principle.

The best fix is to add a `permissions` block near the top of `.github/workflows/ppa-upload.yml` (at the workflow level, alongside `name` and `on`). This will apply to all jobs in this workflow, including `upload-ppa`, without changing any functional behavior. Specifically, insert:

```yaml
permissions:
  contents: read
```

between the `name:` declaration (line 1) and the `on:` block (line 3). No changes are required inside the `jobs:` section, and no additional imports or methods are needed because this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
