### PR TITLE
fix: set errno in virtual filesystem helpers before returning -1

### DIFF
--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -920,6 +920,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 {
 	if (path == nullptr) {
 		write_log("my_mkdir: null path provided\n");
+		errno = EINVAL;
 		return -1;
 	}
 
@@ -932,9 +933,11 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		if (fs::exists(utf8_path, ec)) {
 			if (fs::is_directory(utf8_path, ec)) {
 				write_log("my_mkdir: directory %s already exists\n", path);
+				errno = EEXIST;
 				return -1;
 			}
 			write_log("my_mkdir: path %s exists but is not a directory\n", path);
+			errno = EEXIST;
 			return -1;
 		}
 
@@ -944,6 +947,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 			if (!fs::create_directories(parent, ec)) {
 				write_log("my_mkdir: failed to create parent directories for %s: %s\n",
 					path, ec.message().c_str());
+				if (errno == 0) errno = EIO;
 				return -1;
 			}
 		}
@@ -960,6 +964,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	catch (const std::exception& e) {
 		write_log("my_mkdir: exception while creating directory %s: %s\n",
 			path, e.what());
+		errno = EIO;
 		return -1;
 	}
 }
@@ -1193,6 +1198,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 {
 	if (!path) {
 		write_log("my_rmdir: null directory path provided\n");
+		errno = ENOENT;
 		return -1;
 	}
 
@@ -1205,11 +1211,13 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		std::error_code ec;
 		if (!fs::exists(dirpath, ec)) {
 			write_log("my_rmdir: directory %s does not exist\n", path);
+			errno = ENOENT;
 			return -1;
 		}
 
 		if (!fs::is_directory(dirpath, ec)) {
 			write_log("my_rmdir: path %s is not a directory\n", path);
+			errno = ENOTDIR;
 			return -1;
 		}
 
@@ -1231,6 +1239,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 
 		if (has_real_files) {
 			write_log("my_rmdir: directory %s is not empty\n", path);
+			errno = ENOTEMPTY;
 			return -1;
 		}
 
@@ -1254,6 +1263,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	catch (const std::exception& e) {
 		write_log("my_rmdir: exception while removing directory %s: %s\n",
 			path, e.what());
+		errno = EIO;
 		return -1;
 	}
 }
@@ -1262,6 +1272,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 {
 	if (!path) {
 		write_log("my_unlink: null file path provided\n");
+		errno = ENOENT;
 		return -1;
 	}
 
@@ -1272,6 +1283,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 
 		if (filepath.empty()) {
 			write_log("my_unlink: empty path provided\n");
+			errno = ENOENT;
 			return -1;
 		}
 
@@ -1279,17 +1291,20 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		std::error_code ec;
 		if (!fs::exists(filepath, ec)) {
 			write_log("my_unlink: file %s does not exist\n", path);
+			errno = ENOENT;
 			return -1;
 		}
 
 		if (!fs::is_regular_file(filepath, ec)) {
 			write_log("my_unlink: %s is not a regular file\n", path);
+			errno = EPERM;
 			return -1;
 		}
 
 		// Ensure we have write permission to delete
 		if (!fs::is_regular_file(filepath) || (fs::status(filepath, ec).permissions() & fs::perms::owner_all) == fs::perms::none) {
 			write_log("my_unlink: insufficient permissions to remove %s\n", path);
+			errno = EACCES;
 			return -1;
 		}
 
@@ -1298,6 +1313,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		if (!fs::remove(filepath, ec)) {
 			write_log("my_unlink: remove failed for %s: %s\n",
 				path, ec.message().c_str());
+			errno = EIO;
 			return -1;
 		}
 
@@ -1311,6 +1327,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	catch (const std::exception& e) {
 		write_log("my_unlink: exception while removing %s: %s\n",
 			path, e.what());
+		errno = EIO;
 		return -1;
 	}
 }
@@ -1321,11 +1338,13 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	if (oldname == nullptr || newname == nullptr) {
 		write_log("my_rename: invalid arguments - %s\n",
 			oldname == nullptr ? "old filename is null" : "new filename is null");
+		errno = EINVAL;
 		return -1;
 	}
 
 	if (*oldname == '\0' || *newname == '\0') {
 		write_log("my_rename: empty filename provided\n");
+		errno = EINVAL;
 		return -1;
 	}
 
@@ -1337,6 +1356,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		// Check if paths are valid after conversion
 		if (old_output.empty() || new_output.empty()) {
 			write_log("my_rename: path conversion failed\n");
+			errno = EINVAL;
 			return -1;
 		}
 
@@ -1380,6 +1400,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	catch (const std::exception& e) {
 		write_log("my_rename: unexpected error while renaming '%s' to '%s': %s\n",
 			oldname, newname, e.what());
+		errno = EIO;
 		return -1;
 	}
 }
@@ -1389,12 +1410,14 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	// Input validation with detailed error reporting
 	if (mos == nullptr) {
 		write_log("my_lseek: null file descriptor provided\n");
+		errno = EBADF;
 		return -1;
 	}
 
 	if (mos->fd < 0 || mos->path == nullptr) {
 		write_log("my_lseek: invalid file descriptor state (fd=%d, path=%s)\n",
 			mos->fd, mos->path ? mos->path : "null");
+		errno = EBADF;
 		return -1;
 	}
 
@@ -1402,6 +1425,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	if (whence != SEEK_SET && whence != SEEK_CUR && whence != SEEK_END) {
 		write_log("my_lseek: invalid whence parameter %d for file %s\n",
 			whence, mos->path);
+		errno = EINVAL;
 		return -1;
 	}
 


### PR DESCRIPTION
## Summary

File and directory deletion on host-mapped virtual filesystem volumes (e.g. NFS-backed directories) silently fails for programs that rely on AmigaOS error codes to drive their behavior. The operation appears to succeed from the program's perspective, but the files reappear on the next directory scan.

## The Problem

Directory Opus deletes a non-empty directory by first calling `DeleteFile()` on the directory itself. When the filesystem handler returns `ERROR_DIRECTORY_NOT_EMPTY`, DOpus knows to recurse: enumerate the contents, delete each entry bottom-up, then retry the now-empty directory. This is standard AmigaOS behavior and works correctly on FFS volumes.

On host-mapped virtual filesystem volumes, this sequence breaks. `action_delete_object` in `filesys.cpp` calls `my_rmdir()`, which detects the directory is not empty via `fs::directory_iterator` and returns `-1` -- but without setting `errno`. The caller then invokes `dos_errno()`, which reads whatever stale value `errno` happens to hold (typically `ENOENT`/2, left over from an earlier `fs::exists()` check inside `my_rmdir` itself). This maps to `ERROR_OBJECT_NOT_AROUND` (205) instead of `ERROR_DIRECTORY_NOT_EMPTY` (232).

DOpus receives "object not found," interprets this as the directory already being gone, removes it from the display, and moves on. On the next refresh it re-reads the host directory and discovers everything is still there. From the user's perspective, deleted items silently reappear.

The same pattern -- returning `-1` without setting `errno` -- exists in `my_unlink`, `my_mkdir`, `my_rename`, and `my_lseek`. Every early-return path that bypasses the actual syscall (which would set `errno` itself) leaves the caller reading a stale or unrelated `errno` value.

### Diagnosis methodology

The root cause was isolated through progressively targeted instrumentation:

1. **inotifywait** on the host NFS mount confirmed zero `DELETE`/`UNLINK` events during DOpus operations, while CLI `delete` produced the expected `unlink()` syscalls
2. **strace** attached to the Amiberry process confirmed the same: CLI delete triggered `unlink()`, DOpus delete produced nothing
3. **write_log instrumentation** in `action_delete_object` confirmed DOpus *was* sending `ACTION_DELETE_OBJECT` packets and reaching `my_rmdir()`, but the rmdir was failing
4. **errno capture** at the failure site revealed `errno=2 (ENOENT)` and `dos_errno=205` instead of the expected `errno=39 (ENOTEMPTY)` and `dos_errno=232`

## The Fix

Add the appropriate `errno` assignment before every `return -1` that originates from a validation check or exception handler rather than a failed syscall. Syscall failure paths (`rmdir()`, `unlink()`, `rename()`, `mkdir()`, `lseek()`) already set `errno` and are left untouched.

24 sites across 5 functions:

| Function | Sites | errno values |
|----------|-------|-------------|
| `my_mkdir` | 5 | `EINVAL`, `EEXIST` (x2), conditional `EIO`, `EIO` |
| `my_rmdir` | 5 | `ENOENT` (x2), `ENOTDIR`, `ENOTEMPTY`, `EIO` |
| `my_unlink` | 7 | `ENOENT` (x3), `EPERM`, `EACCES`, `EIO` (x2) |
| `my_rename` | 4 | `EINVAL` (x3), `EIO` |
| `my_lseek` | 3 | `EBADF` (x2), `EINVAL` |

## Testing

Tested on Debian 13 (kernel 6.12), Proxmox VM, emulated A4000/040. STORE: volume is a host-mapped directory backed by an NFS4 mount. File management performed via Directory Opus 4.x.

| Test | Before | After |
|------|--------|-------|
| Single file delete (DOpus) | Works | Works |
| Non-empty directory delete (DOpus) | Appears to succeed, reappears on refresh | DOpus recurses and deletes correctly |
| CLI `delete ... ALL` | Works | Works |
| File create/read/modify (DOpus) | Works | Works |

Generated with [Claude Code](https://claude.com/claude-code)