### PR TITLE
Fix 100% CPU spin in sleep_millis2 due to unlocked mutex

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -575,10 +575,12 @@ static int init_mmtimer()
 
 void sleep_cpu_wakeup()
 {
+	SDL_LockMutex(cpu_wakeup_mutex);
 	if (!cpu_wakeup_event_triggered) {
 		cpu_wakeup_event_triggered = true;
 		SDL_SignalCondition(cpu_wakeup_event);
 	}
+	SDL_UnlockMutex(cpu_wakeup_mutex);
 }
 
 int get_sound_event();
@@ -590,14 +592,19 @@ static int sleep_millis2(int ms, const bool main)
 	if (ms < 0)
 		ms = -ms;
 	if (main) {
-		if (SDL_WaitConditionTimeout(cpu_wakeup_event, cpu_wakeup_mutex, 0)) {
+		SDL_LockMutex(cpu_wakeup_mutex);
+		if (cpu_wakeup_event_triggered) {
+			cpu_wakeup_event_triggered = false;
+			SDL_UnlockMutex(cpu_wakeup_mutex);
 			return 0;
 		}
+		SDL_UnlockMutex(cpu_wakeup_mutex);
 		start = read_processor_time();
 
 		SDL_Delay(ms);
-		//SDL_WaitConditionTimeout(cpu_wakeup_event, cpu_wakeup_mutex, ms);
+		SDL_LockMutex(cpu_wakeup_mutex);
 		cpu_wakeup_event_triggered = false;
+		SDL_UnlockMutex(cpu_wakeup_mutex);
 	}
 	else {
 		SDL_Delay(ms);


### PR DESCRIPTION
## Problem

After the SDL3 migration (#1826), the main emulation thread spins at 100% CPU instead of sleeping between frames. This wastes power and causes thermal throttling, especially on low-power devices like Raspberry Pi.

## Root Cause

`sleep_millis2()` polls `SDL_WaitConditionTimeout(cpu_wakeup_event, cpu_wakeup_mutex, 0)` to check for pending PPC wakeup events before sleeping. The mutex is never locked before this call, which is undefined behavior per POSIX `pthread_cond_timedwait`.

In SDL2, the undefined behavior was benign: `pthread_cond_timedwait` on an unlocked mutex returned `EPERM`, which SDL2's wrapper mapped to a non-zero error code. The caller's `== 0` check treated this as "not signaled" and fell through to `SDL_Delay()`.

In SDL3, the same `EPERM` falls into a `default:` switch case in `SDL_WaitConditionTimeoutNS()` (src/thread/pthread/SDL_syscond.c:123) that returns `true`. The caller interprets `true` as "condition was signaled" and skips the `SDL_Delay()` entirely. Since the frame timing loop calls this function on every iteration, the main thread never sleeps and busy-waits at full CPU.

Confirmed via `strace`: the main thread made zero `clock_nanosleep` syscalls (from `SDL_Delay`) while generating ~23K futex calls/sec from the broken condition variable check.

## Fix

Lock `cpu_wakeup_mutex` before accessing the condition variable and flag, in both `sleep_millis2()` and `sleep_cpu_wakeup()`. Replace the non-blocking `SDL_WaitConditionTimeout(timeout=0)` poll with a direct check of the `cpu_wakeup_event_triggered` flag -- the flag is the actual predicate, and a zero-timeout CV wait is susceptible to spurious wakeups from `pthread_cond_timedwait`.

## Validation

Tested on Debian 13 (trixie) with SDL3 3.2.10 on an x86_64 VM. Measured with `top` and `strace` before and after:

| Metric | Before | After |
|--------|--------|-------|
| Total CPU (main + threads) | ~120% | ~35% |
| Main thread CPU | ~96% | ~18% |
| `clock_nanosleep` calls (main, 5s) | 0 | Normal |
| `futex` calls (main, 5s) | 114K (spinning) | 69K (normal sync) |

The remaining ~35% is normal emulation overhead for a 68040 JIT configuration with software OpenGL rendering (no GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)