### PR TITLE
Fix blurry scaling on Linux with desktop scale != 100%

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -1609,12 +1609,10 @@ static int setsizemove(AmigaMonitor* mon, SDL_Window* hWnd)
 				int h = mon->mainwin_rect.h;
 				const int content_w = w - mon->window_extra_width;
 				const int content_h = h - mon->window_extra_height;
-				const int logical_w = DPIHandler::unscale_window_dimension(content_w);
-				const int logical_h = DPIHandler::unscale_window_dimension(content_h);
-				if (logical_w != changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.width ||
-					logical_h != changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.height) {
-					changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.width = logical_w;
-					changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.height = logical_h;
+				if (content_w != changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.width ||
+					content_h != changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.height) {
+					changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.width = content_w;
+					changed_prefs.gfx_monitor[mon->monitor_id].gfx_size_win.height = content_h;
 					set_config_changed();
 				}
 				//if (mon->hStatusWnd)

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -663,11 +663,6 @@ static int create_windows(struct AmigaMonitor* mon)
 			nh = currprefs.gfx_monitor[mon->monitor_id].gfx_size_win.height;
 		}
 
-		if (!fullscreen && !fullwindow) {
-			nw = DPIHandler::scale_window_dimension(nw);
-			nh = DPIHandler::scale_window_dimension(nh);
-		}
-
 		if (fullwindow) {
 			SDL_Rect rc = md->rect;
 			nx = rc.x;
@@ -776,11 +771,6 @@ static int create_windows(struct AmigaMonitor* mon)
 	rc.w = mon->currentmode.current_width;
 	rc.h = mon->currentmode.current_height;
 
-	if (!fullscreen && !fullwindow) {
-		rc.w = DPIHandler::scale_window_dimension(rc.w);
-		rc.h = DPIHandler::scale_window_dimension(rc.h);
-	}
-
 	oldx = rc.x;
 	oldy = rc.y;
 
@@ -881,10 +871,6 @@ static int create_windows(struct AmigaMonitor* mon)
 	GetWindowRect(mon->amiga_window, &rc2);
 	int expected_client_width = mon->currentmode.current_width;
 	int expected_client_height = mon->currentmode.current_height;
-	if (!fullscreen && !fullwindow) {
-		expected_client_width = DPIHandler::scale_window_dimension(expected_client_width);
-		expected_client_height = DPIHandler::scale_window_dimension(expected_client_height);
-	}
 	mon->window_extra_width = rc2.w - expected_client_width;
 	mon->window_extra_height = rc2.h - expected_client_height;
 

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -146,7 +146,11 @@ bool OpenGLRenderer::has_context() const
 
 SDL_WindowFlags OpenGLRenderer::get_window_flags() const
 {
-	return SDL_WINDOW_OPENGL;
+	SDL_WindowFlags flags = SDL_WINDOW_OPENGL;
+#if !defined(__ANDROID__)
+	flags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
+#endif
+	return flags;
 }
 
 bool OpenGLRenderer::set_context_attributes(int mode)
@@ -1238,8 +1242,8 @@ void OpenGLRenderer::render_osd(const int monid, int x, int y, int w, int h)
 				glGenTextures(1, &m_overlay.osd_texture);
 				glActiveTexture(GL_TEXTURE0);
 				glBindTexture(GL_TEXTURE_2D, m_overlay.osd_texture);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 				last_osd_w = 0;
 				last_osd_h = 0;
 				last_osd_hash = 0;

--- a/src/osdep/sdl_renderer.cpp
+++ b/src/osdep/sdl_renderer.cpp
@@ -56,7 +56,11 @@ bool SDLRenderer::has_context() const
 
 SDL_WindowFlags SDLRenderer::get_window_flags() const
 {
-	return 0; // No special flags needed for SDL software rendering
+#if !defined(__ANDROID__)
+	return SDL_WINDOW_HIGH_PIXEL_DENSITY;
+#else
+	return 0;
+#endif
 }
 
 bool SDLRenderer::set_context_attributes(int /*mode*/)
@@ -198,8 +202,10 @@ void SDLRenderer::sync_osd_texture(int monid, int led_width, int led_height)
 	// Create texture if needed
 	if (!mon->statusline_texture) {
 		mon->statusline_texture = SDL_CreateTexture(mon->amiga_renderer, SDL_PIXELFORMAT_RGBA32, SDL_TEXTUREACCESS_STREAMING, led_width, led_height);
-		if (mon->statusline_texture)
+		if (mon->statusline_texture) {
 			SDL_SetTextureBlendMode(mon->statusline_texture, SDL_BLENDMODE_BLEND);
+			SDL_SetTextureScaleMode(mon->statusline_texture, SDL_SCALEMODE_NEAREST);
+		}
 	}
 
 	// Upload surface pixels to texture


### PR DESCRIPTION
## Summary

Fixes #1880 — Blurry scaling on Linux unless desktop scale is set to 100%.

## Changes

### Issue 1: Blurry Amiga output with HiDPI desktop scaling
- Add `SDL_WINDOW_HIGH_PIXEL_DENSITY` to both `OpenGLRenderer::get_window_flags()` and `SDLRenderer::get_window_flags()` (non-Android), matching the GUI window which already had this flag
- Remove `DPIHandler::scale_window_dimension()` / `unscale_window_dimension()` calls for the emulation window — these were a workaround for the missing flag; with `HIGH_PIXEL_DENSITY`, SDL3 handles logical→physical pixel mapping natively

**Root cause**: Without `SDL_WINDOW_HIGH_PIXEL_DENSITY`, the Wayland compositor bilinear-upscales the low-resolution backing buffer to fill physical pixels, destroying any nearest-neighbor or integer scaling applied by Amiberry.

### Issue 2: Blurry OSD/status bar (even at 100% scale)
- Change OSD texture filtering from `GL_LINEAR` to `GL_NEAREST` in OpenGL renderer
- Add explicit `SDL_SetTextureScaleMode(SDL_SCALEMODE_NEAREST)` on statusline texture in SDL renderer

**Root cause**: The status line surface is only 640×11 pixels, stretched to full window width with linear filtering.

## Files Changed
- `src/osdep/opengl_renderer.cpp` — HIGH_PIXEL_DENSITY flag + OSD nearest filtering
- `src/osdep/sdl_renderer.cpp` — HIGH_PIXEL_DENSITY flag + OSD nearest filtering
- `src/osdep/gfx_window.cpp` — Remove 3 `scale_window_dimension()` call sites
- `src/osdep/amiberry.cpp` — Remove `unscale_window_dimension()` calls

## Testing
- [x] macOS Retina — no regressions
- [x] Linux Wayland with >100% desktop scale (reporter's environment: KDE Plasma 6.6.3)
- [x] Windows — regression check
- [x] Fullscreen / full-window modes