### PR TITLE
Bundle SDL3 shared libraries in Bookworm .deb packages

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -660,11 +660,13 @@ jobs:
             artifact_name: amiberry-debian-bookworm-amd64
             release_name: debian-bookworm-amd64
             codename: bookworm
+            extra_cmake_args: -DBUNDLE_SDL=ON
           - name: trixie
             image: midwan/amiberry-debian-x86_64:trixie
             artifact_name: amiberry-debian-trixie-amd64
             release_name: debian-trixie-amd64
             codename: trixie
+            extra_cmake_args:
     steps:
       - uses: actions/checkout@v5
         with:
@@ -673,7 +675,7 @@ jobs:
       - name: Run the build process with Docker
         run: |
           docker run --rm -v ${{ github.workspace }}:/build ${{ matrix.image }} \
-            bash -c "cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DDISTRO_CODENAME=${{ matrix.codename }} && cmake --build build -j\$(nproc) && cpack -G DEB --config build/CPackConfig.cmake"
+            bash -c "cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DDISTRO_CODENAME=${{ matrix.codename }} ${{ matrix.extra_cmake_args }} && cmake --build build -j\$(nproc) && cpack -G DEB --config build/CPackConfig.cmake"
 
       - name: Upload artifact
         if: always() && github.ref_type != 'tag'
@@ -709,11 +711,13 @@ jobs:
             artifact_name: amiberry-debian-bookworm-arm64
             release_name: debian-bookworm-arm64
             codename: bookworm
+            extra_cmake_args: -DBUNDLE_SDL=ON
           - name: trixie
             image: midwan/amiberry-debian-aarch64:trixie
             artifact_name: amiberry-debian-trixie-arm64
             release_name: debian-trixie-arm64
             codename: trixie
+            extra_cmake_args:
     steps:
     - uses: actions/checkout@v5
       with:
@@ -722,7 +726,7 @@ jobs:
     - name: Run the build process with Docker
       run: |
         docker run --rm -v ${{ github.workspace }}:/build ${{ matrix.image }} \
-          bash -c "cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-aarch64-linux-gnu.cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DDISTRO_CODENAME=${{ matrix.codename }} && cmake --build build -j\$(nproc) && cpack -G DEB --config build/CPackConfig.cmake"
+          bash -c "cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Toolchain-aarch64-linux-gnu.cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DDISTRO_CODENAME=${{ matrix.codename }} ${{ matrix.extra_cmake_args }} && cmake --build build -j\$(nproc) && cpack -G DEB --config build/CPackConfig.cmake"
 
     - name: Upload artifact
       if: always() && github.ref_type != 'tag'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ option(USE_GLES          "Use OpenGL ES instead of desktop OpenGL (for embedded 
 option(USE_IPC_SOCKET    "Use Unix socket for IPC control (cross-platform)" ON)
 option(WITH_LTO          "Enable Link Time Optimization" OFF)
 option(WITH_OPTIMIZE     "Enable GCC native CPU optimizations" OFF)
+option(BUNDLE_SDL        "Bundle SDL3 shared libraries into the package (for distros without SDL3)" OFF)
 
 # Automatically disable PCem on RISC-V targets
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv" OR CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "riscv")

--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -603,6 +603,14 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 # ImGui include dirs (always enabled)
 target_include_directories(${PROJECT_NAME} PRIVATE external/imgui external/ImGuiFileDialog)
 
+# When bundling SDL3, set RPATH so the binary finds the co-installed shared libs.
+if(BUNDLE_SDL AND CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set_target_properties(${PROJECT_NAME} PROPERTIES
+        INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}"
+        BUILD_RPATH_USE_ORIGIN ON
+    )
+endif()
+
 # Install the executable
 install(TARGETS ${PROJECT_NAME}
         BUNDLE DESTINATION .

--- a/cmake/linux/install.cmake
+++ b/cmake/linux/install.cmake
@@ -24,6 +24,67 @@ install(FILES $<TARGET_FILE:capsimage>
 install(FILES $<TARGET_FILE:floppybridge>
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 
+# Bundle SDL3 shared libraries for distros that don't ship them (e.g. Debian Bookworm).
+# The .so files are resolved from the imported CMake targets created by find_package(SDL3).
+if(BUNDLE_SDL)
+    # Collect SDL3 and SDL3_image shared library paths from their imported targets.
+    set(_bundle_sdl_libs "")
+
+    # SDL3 main library
+    if(TARGET SDL3::SDL3-shared)
+        list(APPEND _bundle_sdl_libs "$<TARGET_FILE:SDL3::SDL3-shared>")
+    elseif(TARGET SDL3::SDL3)
+        list(APPEND _bundle_sdl_libs "$<TARGET_FILE:SDL3::SDL3>")
+    endif()
+
+    # SDL3_image library
+    if(TARGET SDL3_image::SDL3_image-shared)
+        list(APPEND _bundle_sdl_libs "$<TARGET_FILE:SDL3_image::SDL3_image-shared>")
+    elseif(TARGET SDL3_image::SDL3_image)
+        list(APPEND _bundle_sdl_libs "$<TARGET_FILE:SDL3_image::SDL3_image>")
+    endif()
+
+    if(_bundle_sdl_libs)
+        install(FILES ${_bundle_sdl_libs}
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
+
+        # Also install the versioned symlinks (e.g. libSDL3.so.0) so the
+        # dynamic linker finds the correct SONAME at runtime.
+        foreach(_sdl_tgt IN ITEMS SDL3::SDL3-shared SDL3::SDL3 SDL3_image::SDL3_image-shared SDL3_image::SDL3_image)
+            if(TARGET ${_sdl_tgt})
+                get_target_property(_sdl_soname ${_sdl_tgt} IMPORTED_SONAME_RELEASE)
+                if(NOT _sdl_soname)
+                    get_target_property(_sdl_soname ${_sdl_tgt} IMPORTED_SONAME_NOCONFIG)
+                endif()
+                if(NOT _sdl_soname)
+                    get_target_property(_sdl_soname ${_sdl_tgt} IMPORTED_SONAME)
+                endif()
+                if(_sdl_soname)
+                    get_target_property(_sdl_loc ${_sdl_tgt} IMPORTED_LOCATION_RELEASE)
+                    if(NOT _sdl_loc)
+                        get_target_property(_sdl_loc ${_sdl_tgt} IMPORTED_LOCATION_NOCONFIG)
+                    endif()
+                    if(NOT _sdl_loc)
+                        get_target_property(_sdl_loc ${_sdl_tgt} IMPORTED_LOCATION)
+                    endif()
+                    if(_sdl_loc)
+                        cmake_path(GET _sdl_loc PARENT_PATH _sdl_dir)
+                        set(_sdl_soname_path "${_sdl_dir}/${_sdl_soname}")
+                        if(EXISTS "${_sdl_soname_path}" AND NOT "${_sdl_soname_path}" STREQUAL "${_sdl_loc}")
+                            install(FILES "${_sdl_soname_path}"
+                                    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
+                        endif()
+                    endif()
+                endif()
+            endif()
+        endforeach()
+
+        message(STATUS "BUNDLE_SDL: SDL3 shared libraries will be installed to ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}")
+    else()
+        message(WARNING "BUNDLE_SDL is ON but no SDL3 shared library targets were found")
+    endif()
+endif()
+
 # This one contains the gamecontrollersdb.txt file
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/controllers
         DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -69,7 +69,12 @@ else()
 endif()
 
 # Linux DEB settings - build dependency list conditionally based on enabled features
-set(_deb_deps "libc6, libstdc++6, libsdl3-0, libsdl3-image0, flac, libmpg123-0, libpng16-16, zlib1g, libcurl4")
+# When BUNDLE_SDL is ON, SDL3 libs are shipped inside the package — no system dependency needed.
+if(BUNDLE_SDL)
+    set(_deb_deps "libc6, libstdc++6, flac, libmpg123-0, libpng16-16, zlib1g, libcurl4")
+else()
+    set(_deb_deps "libc6, libstdc++6, libsdl3-0, libsdl3-image0, flac, libmpg123-0, libpng16-16, zlib1g, libcurl4")
+endif()
 if(USE_ZSTD)
     string(APPEND _deb_deps ", libzstd1")
 endif()
@@ -113,7 +118,11 @@ set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA
         "${CMAKE_SOURCE_DIR}/packaging/linux/scripts/postrm")
 
 # Linux RPM settings - build dependency list conditionally based on enabled features
-set(_rpm_deps "glibc, libstdc++, SDL3, SDL3_image, flac, mpg123, libpng, zlib, libcurl")
+if(BUNDLE_SDL)
+    set(_rpm_deps "glibc, libstdc++, flac, mpg123, libpng, zlib, libcurl")
+else()
+    set(_rpm_deps "glibc, libstdc++, SDL3, SDL3_image, flac, mpg123, libpng, zlib, libcurl")
+endif()
 if(USE_ZSTD)
     string(APPEND _rpm_deps ", zstd")
 endif()


### PR DESCRIPTION
## Summary
- Adds `BUNDLE_SDL` CMake option that bundles SDL3/SDL3_image `.so` files inside the package for distros without system SDL3
- Removes `libsdl3-0` and `libsdl3-image0` from DEB/RPM dependencies when bundling
- Sets RPATH on the binary so it finds the bundled libs at `/usr/lib/amiberry/`
- Enables `BUNDLE_SDL=ON` for Bookworm CI builds (amd64 + arm64); Trixie is unaffected

## Problem
SDL3 is not in Debian Bookworm (12) repositories. The .deb package declared `libsdl3-0` and `libsdl3-image0` as dependencies, making installation fail with "unmet dependencies".

## How it works
When `-DBUNDLE_SDL=ON`:
1. CMake resolves SDL3 and SDL3_image shared library paths from their imported targets
2. The `.so` files and SONAME symlinks are installed to `/usr/lib/amiberry/`
3. The amiberry binary gets `INSTALL_RPATH` set to that directory
4. SDL3 is removed from the package dependency list

## Files changed
- `CMakeLists.txt` — New `BUNDLE_SDL` option
- `cmake/SourceFiles.cmake` — RPATH configuration
- `cmake/linux/install.cmake` — SDL3 `.so` install logic
- `packaging/CMakeLists.txt` — Conditional DEB/RPM dependency lists
- `.github/workflows/c-cpp.yml` — `BUNDLE_SDL=ON` for Bookworm matrix entries

Fixes #1877