### PR TITLE
fix: JIT x86-64 allocation failure within 2GB of globals (#1887)

### DIFF
--- a/src/jit/x86/compemu_support_x86.cpp
+++ b/src/jit/x86/compemu_support_x86.cpp
@@ -303,8 +303,17 @@ void *jit_vm_acquire(uae_u32 size, int options)
 			result = VirtualAlloc(best, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 		}
 		if (!result) {
-			/* Last resort: OS choice (may be out of RIP-relative range) */
+			/* Last resort: OS choice — range-check the result to avoid
+			 * silent RIP-relative overflow in pool allocations that
+			 * bypass alloc_cache()'s post-hoc distance check. */
 			result = VirtualAlloc(NULL, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+			if (result) {
+				intptr_t dist = (intptr_t)result - (intptr_t)base;
+				if (llabs(dist) >= (intptr_t)range) {
+					VirtualFree(result, 0, MEM_RELEASE);
+					result = NULL;
+				}
+			}
 		}
 		return result;
 #else


### PR DESCRIPTION
## Summary

Fixes #1887 — JIT crashes with `FATAL: could not allocate within 2GB of globals` on x86-64 Linux (Fedora 44) after minutes of Workbench usage.

## Root Cause

`jit_vm_acquire()` last-resort fallback used unanchored `mmap` which returned addresses far beyond ±2GB RIP-relative range on modern Linux with ASLR. When the anchor-based hint loop failed to find free space, the fallback got an address like `0x7ffff4f46000` while globals were at `0x4cceb08` — ~128TB apart.

## Changes

**Root cause fix:**
- `jit_vm_acquire()` last-resort now tries `UAE_VM_32BIT` (`MAP_32BIT`) before unanchored `mmap`, keeping allocations in the low 2GB where the binary's `.data` section typically resides
- Uses `jit_vm_alloc_failed()` for consistent `NULL`/`VM_MAP_FAILED` checking

**Graceful degradation (safety net):**
- `LazyBlockAllocator::acquire()` returns `NULL` instead of `jit_abort()` on failure (UAE path)
- `disable_jit_on_runtime_alloc_failure()` sets `cache_enabled=0` and `currprefs.cachesize=0` to fall back to interpreter
- NULL propagation through `alloc_blockinfo`, `alloc_checksum_info`, `alloc_blockinfos`

**State cleanup on failure:**
- `compile_block()` calls `invalidate_block(bi)` before returning when `bi` is partially set up
- `flush_icache_hard(3)` at every failure return point to clear stale `cache_tags[]` and prevent already-compiled blocks from executing after JIT is disabled

## Testing needed

- x86-64 Linux (ideally Fedora 44 or similar with aggressive ASLR) with JIT + Direct memory access
- Sustained Workbench usage to exercise pool allocation pressure
- Verify JIT works normally when allocations succeed
- Verify graceful fallback to interpreter when allocations fail (check log for WARNING messages)