### PR TITLE
fix: align pen/tablet coordinate scaling with mouse handler

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -2215,20 +2215,23 @@ static int pen_eraser;
 
 static void pen_coords_to_tablet(const AmigaMonitor* mon, float x, float y, int* tx, int* ty)
 {
-	int win_w, win_h;
-	SDL_GetWindowSize(mon->amiga_window, &win_w, &win_h);
-
-	// HiDPI: window screen coords → drawable pixels (same as mouse handler)
 	IRenderer* renderer = get_renderer(mon->monitor_id);
 	if (renderer) {
-		int draw_w, draw_h;
-		renderer->get_drawable_size(mon->amiga_window, &draw_w, &draw_h);
-		if (win_w > 0 && draw_w > 0 && win_w != draw_w)
-			x = x * static_cast<float>(draw_w) / static_cast<float>(win_w);
-		if (win_h > 0 && draw_h > 0 && win_h != draw_h)
-			y = y * static_cast<float>(draw_h) / static_cast<float>(win_h);
+		// Transform window coordinates to match render_quad's coordinate space.
+		// SDL renderer: logical presentation space (via SDL_RenderCoordinatesFromWindow).
+		// OpenGL: drawable pixel space (via cached HiDPI scale factors).
+		if (mon->amiga_renderer) {
+			float rx, ry;
+			if (SDL_RenderCoordinatesFromWindow(mon->amiga_renderer, x, y, &rx, &ry)) {
+				x = rx;
+				y = ry;
+			}
+		} else if (mon->hidpi_needs_scaling) {
+			x *= mon->hidpi_scale_x;
+			y *= mon->hidpi_scale_y;
+		}
 
-		// Map relative to the Amiga display area within the drawable
+		// Map relative to the Amiga display area within the render target
 		const SDL_Rect& rq = renderer->render_quad;
 		if (rq.w > 0 && rq.h > 0) {
 			float rx = (x - static_cast<float>(rq.x)) * 4095.0f / static_cast<float>(rq.w);
@@ -2240,6 +2243,8 @@ static void pen_coords_to_tablet(const AmigaMonitor* mon, float x, float y, int*
 	}
 
 	// Fallback: map to full window
+	int win_w, win_h;
+	SDL_GetWindowSize(mon->amiga_window, &win_w, &win_h);
 	*tx = (win_w > 0) ? static_cast<int>(std::clamp(x * 4095.0f / static_cast<float>(win_w), 0.0f, 4095.0f)) : 0;
 	*ty = (win_h > 0) ? static_cast<int>(std::clamp(y * 4095.0f / static_cast<float>(win_h), 0.0f, 4095.0f)) : 0;
 }
@@ -2261,15 +2266,18 @@ static void pen_position_via_mouse(const AmigaMonitor* mon, float x, float y)
 	int32_t px = static_cast<int32_t>(x);
 	int32_t py = static_cast<int32_t>(y);
 
-	IRenderer* renderer = get_renderer(mon->monitor_id);
-	if (renderer) {
-		int win_w, win_h, draw_w, draw_h;
-		SDL_GetWindowSize(mon->amiga_window, &win_w, &win_h);
-		renderer->get_drawable_size(mon->amiga_window, &draw_w, &draw_h);
-		if (win_w > 0 && draw_w > 0 && win_w != draw_w)
-			px = static_cast<int32_t>(x * static_cast<float>(draw_w) / static_cast<float>(win_w));
-		if (win_h > 0 && draw_h > 0 && win_h != draw_h)
-			py = static_cast<int32_t>(y * static_cast<float>(draw_h) / static_cast<float>(win_h));
+	// Match mouse handler coordinate paths:
+	// SDL renderer handles HiDPI + logical presentation in one call.
+	// OpenGL uses cached per-monitor HiDPI scale factors.
+	if (mon->amiga_renderer) {
+		float rx, ry;
+		if (SDL_RenderCoordinatesFromWindow(mon->amiga_renderer, x, y, &rx, &ry)) {
+			px = static_cast<int32_t>(rx);
+			py = static_cast<int32_t>(ry);
+		}
+	} else if (mon->hidpi_needs_scaling) {
+		px = static_cast<int32_t>(x * mon->hidpi_scale_x);
+		py = static_cast<int32_t>(y * mon->hidpi_scale_y);
 	}
 
 	setmousestate(0, 0, px, 1);


### PR DESCRIPTION
## Problem

The pen event handlers (`pen_coords_to_tablet`, `pen_position_via_mouse`) computed HiDPI scaling inline on every event via `get_renderer()` + `get_drawable_size()`. This produced coordinates in drawable pixel space regardless of the active rendering backend.

This is incorrect on the SDL renderer path because `render_quad` — the rectangle defining the Amiga display area — lives in SDL logical presentation space, not drawable pixel space. When SDL's `SDL_SetRenderLogicalPresentation` scales the Amiga framebuffer (e.g., 756x576 logical into a 720x568 window with letterboxing), the coordinate space mismatch causes pen/tablet input to be offset. The same issue affects `pen_position_via_mouse`, which feeds `setmousestate` without accounting for the logical presentation transform.

## Fix

Apply the same two-path coordinate pipeline that the mouse handler uses:

- **SDL renderer**: `SDL_RenderCoordinatesFromWindow()` transforms window coordinates through SDL's internal HiDPI scaling, logical presentation, and viewport in a single call. The output is in logical presentation space, matching `render_quad`.
- **OpenGL**: Cached per-monitor HiDPI scale factors (`mon->hidpi_scale_x/y`) convert window coordinates to drawable pixel space, matching `render_quad` in that backend.

Both paths ensure pen coordinates and `render_quad` are in the same coordinate space before the tablet mapping or `setmousestate` call.

`SDL_ConvertEventToRenderCoordinates()` was considered but not used: pen events arrive through `const SDL_Event&` (would need a copy or signature change), and the point-based `SDL_RenderCoordinatesFromWindow` provides more precise control — SDL's own issue tracker ([#9424](https://github.com/libsdl-org/SDL/issues/9424)) recommends it over event-level conversion for applications needing accurate coordinate control.

## Relationship to #1870

This is a companion to #1870, which applies the same coordinate pipeline fix to the mouse motion handler and fixes the Denise renderer left border alignment. Together they complete the SDL3 logical presentation input coordinate fix across all input device types (mouse, pen, tablet).

## Testing

Built and verified that mouse tracking behavior is unchanged from upstream master. Pen/tablet coordinate paths are structurally identical to the mouse handler pipeline. No pen hardware available for direct validation, but the coordinate space analysis confirms correctness: after transformation, both pen coordinates and `render_quad` are in logical presentation space (SDL renderer) or drawable pixel space (OpenGL).