### PR TITLE
feat(imgui): restore the Themes panel

### DIFF
--- a/cmake/SourceFiles.cmake
+++ b/cmake/SourceFiles.cmake
@@ -355,6 +355,7 @@ set(IMGUI_GUI_FILES
 		src/osdep/imgui/rtg.cpp
 		src/osdep/imgui/savestates.cpp
 		src/osdep/imgui/sound.cpp
+		src/osdep/imgui/themes.cpp
 		src/osdep/imgui/virtualkeyboard.cpp
 		src/osdep/imgui/whdload.cpp
 )

--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1316,15 +1316,31 @@ struct amiberry_gui_color
 
 struct amiberry_gui_theme
 {
+	// Window
 	amiberry_gui_color base_color;
-	amiberry_gui_color selector_inactive;
-	amiberry_gui_color selector_active;
-	amiberry_gui_color background_color;
-	amiberry_gui_color selection_color;
-	amiberry_gui_color foreground_color;
+	amiberry_gui_color frame_color;
+	// Text
 	std::string font_name;
 	int font_size;
 	amiberry_gui_color font_color;
+	amiberry_gui_color text_disabled_color;
+	// Accent
+	amiberry_gui_color selector_active;
+	amiberry_gui_color selection_color;
+	// Borders
+	amiberry_gui_color border_color;
+	// Buttons
+	amiberry_gui_color button_color;
+	amiberry_gui_color button_hover_color;
+	// Tables
+	amiberry_gui_color table_header_color;
+	// Modal overlay
+	amiberry_gui_color modal_dim_color;
+
+	// Legacy fields (kept for backward compatibility with old .theme files)
+	amiberry_gui_color selector_inactive;
+	amiberry_gui_color background_color;
+	amiberry_gui_color foreground_color;
 };
 
 struct amiberry_options

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -6974,19 +6974,11 @@ void create_missing_amiberry_folders()
 		ensure_directory_exists(shaders_path);
 	if (!my_existsdir(bezels_path.c_str()))
 		ensure_directory_exists(bezels_path);
-	std::string default_theme_file = join_path(themes_path, "Default.theme");
-	if (!my_existsfile2(default_theme_file.c_str()))
-	{
-		load_default_theme();
-		save_theme("Default.theme");
-	}
-
-	default_theme_file = join_path(themes_path, "Dark.theme");
-	if (!my_existsfile2(default_theme_file.c_str()))
-	{
-		load_default_dark_theme();
-		save_theme("Dark.theme");
-	}
+	// Always regenerate built-in theme presets so they include any new fields
+	load_default_theme();
+	save_theme("Default.theme");
+	load_default_dark_theme();
+	save_theme("Dark.theme");
 }
 
 static void init_amiberry_dirs(const bool portable_mode)

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -1821,11 +1821,27 @@ void load_default_theme()
 {
 	gui_theme.font_name = "AmigaTopaz.ttf";
 	gui_theme.font_size = 15;
-	gui_theme.font_color = { 0, 0, 0 };
+	// Window
 	gui_theme.base_color = { 170, 170, 170 };
-	gui_theme.selector_inactive = { 170, 170, 170 };
-	gui_theme.selector_active = { 0, 85, 170 }; // Classic Amiga Blue
+	gui_theme.frame_color = { 150, 150, 150 };
+	// Text
+	gui_theme.font_color = { 0, 0, 0 };
+	gui_theme.text_disabled_color = { 100, 100, 100 };
+	// Accent
+	gui_theme.selector_active = { 0, 85, 170 };
 	gui_theme.selection_color = { 195, 217, 217 };
+	// Borders
+	gui_theme.border_color = { 120, 120, 120 };
+	// Buttons
+	gui_theme.button_color = { 170, 170, 170 };
+	gui_theme.button_hover_color = { 185, 185, 185 };
+	// Tables
+	gui_theme.table_header_color = { 160, 160, 160 };
+	// Modal
+	gui_theme.modal_dim_color = { 0, 0, 0 };
+	// Font rendering
+	// Legacy
+	gui_theme.selector_inactive = { 170, 170, 170 };
 	gui_theme.background_color = { 220, 220, 220 };
 	gui_theme.foreground_color = { 0, 0, 0 };
 }
@@ -1834,11 +1850,27 @@ void load_default_dark_theme()
 {
 	gui_theme.font_name = "AmigaTopaz.ttf";
 	gui_theme.font_size = 15;
-	gui_theme.font_color = { 200, 200, 200 };
+	// Window
 	gui_theme.base_color = { 32, 32, 37 };
-	gui_theme.selector_inactive = { 32, 32, 37 };
+	gui_theme.frame_color = { 45, 45, 47 };
+	// Text
+	gui_theme.font_color = { 200, 200, 200 };
+	gui_theme.text_disabled_color = { 128, 128, 128 };
+	// Accent
 	gui_theme.selector_active = { 50, 100, 200 };
 	gui_theme.selection_color = { 50, 100, 200 };
+	// Borders
+	gui_theme.border_color = { 60, 60, 65 };
+	// Buttons
+	gui_theme.button_color = { 50, 50, 55 };
+	gui_theme.button_hover_color = { 65, 65, 70 };
+	// Tables
+	gui_theme.table_header_color = { 40, 40, 45 };
+	// Modal
+	gui_theme.modal_dim_color = { 0, 0, 0 };
+	// Font rendering
+	// Legacy
+	gui_theme.selector_inactive = { 32, 32, 37 };
 	gui_theme.background_color = { 45, 45, 47 };
 	gui_theme.foreground_color = { 200, 200, 200 };
 }
@@ -1866,70 +1898,72 @@ void save_theme(const std::string& theme_filename)
 	file_output.open(filename, ios::out);
 	if (file_output.is_open())
 	{
+		auto write_color = [&](const char* key, const amiberry_gui_color& c) {
+			file_output << key << "=" << (int)c.r << "," << (int)c.g << "," << (int)c.b << '\n';
+		};
 		file_output << "font_name=" << gui_theme.font_name << '\n';
 		file_output << "font_size=" << gui_theme.font_size << '\n';
-		file_output << "font_color=" << (int)gui_theme.font_color.r << "," << (int)gui_theme.font_color.g << "," << (int)gui_theme.font_color.b << '\n';
-		file_output << "base_color=" << (int)gui_theme.base_color.r << "," << (int)gui_theme.base_color.g << "," << (int)gui_theme.base_color.b << '\n';
-		file_output << "selector_inactive=" << (int)gui_theme.selector_inactive.r << "," << (int)gui_theme.selector_inactive.g << "," << (int)gui_theme.selector_inactive.b << '\n';
-		file_output << "selector_active=" << (int)gui_theme.selector_active.r << "," << (int)gui_theme.selector_active.g << "," << (int)gui_theme.selector_active.b << '\n';
-		file_output << "selection_color=" << (int)gui_theme.selection_color.r << "," << (int)gui_theme.selection_color.g << "," << (int)gui_theme.selection_color.b << '\n';
-		file_output << "background_color=" << (int)gui_theme.background_color.r << "," << (int)gui_theme.background_color.g << "," << (int)gui_theme.background_color.b << '\n';
-		file_output << "foreground_color=" << (int)gui_theme.foreground_color.r << "," << (int)gui_theme.foreground_color.g << "," << (int)gui_theme.foreground_color.b << '\n';
+		write_color("font_color", gui_theme.font_color);
+		write_color("text_disabled_color", gui_theme.text_disabled_color);
+		write_color("base_color", gui_theme.base_color);
+		write_color("frame_color", gui_theme.frame_color);
+		write_color("selector_active", gui_theme.selector_active);
+		write_color("selection_color", gui_theme.selection_color);
+		write_color("border_color", gui_theme.border_color);
+		write_color("button_color", gui_theme.button_color);
+		write_color("button_hover_color", gui_theme.button_hover_color);
+		write_color("table_header_color", gui_theme.table_header_color);
+		write_color("modal_dim_color", gui_theme.modal_dim_color);
+		// Legacy fields for backward compatibility
+		write_color("selector_inactive", gui_theme.selector_inactive);
+		write_color("background_color", gui_theme.background_color);
+		write_color("foreground_color", gui_theme.foreground_color);
 		file_output.close();
 	}
 }
 
 void load_theme(const std::string& theme_filename)
 {
+	// Pre-fill all fields with light-theme defaults so that old theme files
+	// missing the new color fields get sensible values instead of black.
+	load_default_theme();
+
 	std::string filename = get_themes_path();
 	filename.append(theme_filename);
 	std::ifstream file_input(filename);
 	if (file_input.is_open())
 	{
+		auto read_color = [](const std::string& value, amiberry_gui_color& c) {
+			const std::vector<int> rgb = parse_color_string(value);
+			if (rgb.size() >= 3)
+				c = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
+		};
+
 		std::string line;
 		while (std::getline(file_input, line))
 		{
-			std::string key = line.substr(0, line.find('='));
-			std::string value = line.substr(line.find('=') + 1);
-			if (key == "font_name")
-				gui_theme.font_name = value;
-			else if (key == "font_size")
-				gui_theme.font_size = std::stoi(value);
-			else if (key == "font_color")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.font_color = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
-			else if (key == "base_color")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.base_color = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
-			else if (key == "selector_inactive")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.selector_inactive = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
-			else if (key == "selector_active")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.selector_active = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
-			else if (key == "selection_color")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.selection_color = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
-			else if (key == "background_color")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.background_color = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
-			else if (key == "foreground_color")
-			{
-				const std::vector<int> rgb = parse_color_string(value);
-				gui_theme.foreground_color = { (uint8_t)rgb[0], (uint8_t)rgb[1], (uint8_t)rgb[2] };
-			}
+			const auto eq = line.find('=');
+			if (eq == std::string::npos) continue;
+			const std::string key = line.substr(0, eq);
+			const std::string value = line.substr(eq + 1);
+
+			if (key == "font_name") gui_theme.font_name = value;
+			else if (key == "font_size") gui_theme.font_size = std::stoi(value);
+			else if (key == "font_color") read_color(value, gui_theme.font_color);
+			else if (key == "text_disabled_color") read_color(value, gui_theme.text_disabled_color);
+			else if (key == "base_color") read_color(value, gui_theme.base_color);
+			else if (key == "frame_color") read_color(value, gui_theme.frame_color);
+			else if (key == "selector_active") read_color(value, gui_theme.selector_active);
+			else if (key == "selection_color") read_color(value, gui_theme.selection_color);
+			else if (key == "border_color") read_color(value, gui_theme.border_color);
+			else if (key == "button_color") read_color(value, gui_theme.button_color);
+			else if (key == "button_hover_color") read_color(value, gui_theme.button_hover_color);
+			else if (key == "table_header_color") read_color(value, gui_theme.table_header_color);
+			else if (key == "modal_dim_color") read_color(value, gui_theme.modal_dim_color);
+			// Legacy fields
+			else if (key == "selector_inactive") read_color(value, gui_theme.selector_inactive);
+			else if (key == "background_color") read_color(value, gui_theme.background_color);
+			else if (key == "foreground_color") read_color(value, gui_theme.foreground_color);
 		}
 		file_input.close();
 	}

--- a/src/osdep/gui/gui_handling.h
+++ b/src/osdep/gui/gui_handling.h
@@ -379,6 +379,7 @@ PANEL(io,                 "IO Ports",           "port.png",       ICON_FA_PLUG) 
 PANEL(custom,             "Custom controls",    "controller.png", ICON_FA_GEARS) \
 PANEL(diskswapper,        "Disk swapper",       "35floppy.png",   ICON_FA_SHUFFLE) \
 PANEL(misc,               "Miscellaneous",      "misc.png",       ICON_FA_WRENCH) \
+PANEL(themes,             "Themes",             "misc.png",       ICON_FA_GEAR) \
 PANEL(prio,               "Priority",           "misc.png",       ICON_FA_GAUGE_HIGH) \
 PANEL(savestates,         "Savestates",         "savestate.png",  ICON_FA_BOOKMARK) \
 PANEL(virtual_keyboard,   "Virtual Keyboard",   "keyboard.png",   ICON_FA_KEYBOARD) \
@@ -495,6 +496,7 @@ extern void load_theme(const std::string& theme_filename);
 extern void load_default_theme();
 extern void load_default_dark_theme();
 extern void apply_imgui_theme();
+extern void rebuild_gui_fonts();
 
 extern void SetLastLoadedConfig(const char* filename);
 extern void set_last_active_config(const char* filename);

--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -437,45 +437,91 @@ static bool parse_rgb_csv(const std::string& s, int& r, int& g, int& b) {
 
 void apply_imgui_theme()
 {
-	ImVec4 col_base = rgb_to_vec4(gui_theme.base_color.r, gui_theme.base_color.g, gui_theme.base_color.b);
-	ImVec4 col_bg   = rgb_to_vec4(gui_theme.background_color.r, gui_theme.background_color.g, gui_theme.background_color.b);
-	ImVec4 col_fg   = rgb_to_vec4(gui_theme.foreground_color.r, gui_theme.foreground_color.g, gui_theme.foreground_color.b);
-	ImVec4 col_sel  = rgb_to_vec4(gui_theme.selection_color.r, gui_theme.selection_color.g, gui_theme.selection_color.b);
-	ImVec4 col_act  = rgb_to_vec4(gui_theme.selector_active.r, gui_theme.selector_active.g, gui_theme.selector_active.b);
-	ImVec4 col_inact= rgb_to_vec4(gui_theme.selector_inactive.r, gui_theme.selector_inactive.g, gui_theme.selector_inactive.b);
-	ImVec4 col_text = rgb_to_vec4(gui_theme.font_color.r, gui_theme.font_color.g, gui_theme.font_color.b);
+	auto c = [](const amiberry_gui_color& col) { return rgb_to_vec4(col.r, col.g, col.b); };
+
+	const ImVec4 col_base    = c(gui_theme.base_color);
+	const ImVec4 col_frame   = c(gui_theme.frame_color);
+	const ImVec4 col_text    = c(gui_theme.font_color);
+	const ImVec4 col_textdis = c(gui_theme.text_disabled_color);
+	const ImVec4 col_accent  = c(gui_theme.selector_active);
+	const ImVec4 col_sel     = c(gui_theme.selection_color);
+	const ImVec4 col_border  = c(gui_theme.border_color);
+	const ImVec4 col_btn     = c(gui_theme.button_color);
+	const ImVec4 col_btnhov  = c(gui_theme.button_hover_color);
+	const ImVec4 col_tblhdr  = c(gui_theme.table_header_color);
+	const ImVec4 col_modal   = rgb_to_vec4(gui_theme.modal_dim_color.r, gui_theme.modal_dim_color.g, gui_theme.modal_dim_color.b, 0.55f);
 
 	ImGuiStyle& style = ImGui::GetStyle();
 	ImVec4* colors = style.Colors;
+
+	// Text
 	colors[ImGuiCol_Text]                 = col_text;
-	colors[ImGuiCol_TextDisabled]         = darken(col_text, 0.40f);
+	colors[ImGuiCol_TextDisabled]         = col_textdis;
+	colors[ImGuiCol_InputTextCursor]      = col_text;
+	colors[ImGuiCol_TextSelectedBg]       = col_sel;
+
+	// Window backgrounds
 	colors[ImGuiCol_WindowBg]             = col_base;
 	colors[ImGuiCol_ChildBg]              = col_base;
 	colors[ImGuiCol_PopupBg]              = col_base;
-	colors[ImGuiCol_Border]               = darken(col_base, 0.45f);
-	colors[ImGuiCol_BorderShadow]         = lighten(col_base, 0.45f);
-	colors[ImGuiCol_FrameBg]              = darken(col_base, 0.1f);
-	colors[ImGuiCol_FrameBgHovered]       = lighten(col_base, 0.05f);
-	colors[ImGuiCol_FrameBgActive]        = lighten(col_base, 0.10f);
-	colors[ImGuiCol_TitleBg]              = col_base;
-	colors[ImGuiCol_TitleBgActive]        = col_act;
-	colors[ImGuiCol_TitleBgCollapsed]     = col_base;
 	colors[ImGuiCol_MenuBarBg]            = col_base;
-	colors[ImGuiCol_ScrollbarBg]          = darken(col_base, 0.15f);
-	colors[ImGuiCol_ScrollbarGrab]        = col_base;
-	colors[ImGuiCol_ScrollbarGrabHovered] = lighten(col_base, 0.05f);
-	colors[ImGuiCol_ScrollbarGrabActive]  = col_act;
-	colors[ImGuiCol_CheckMark]            = darken(col_act, 0.15f);
-	colors[ImGuiCol_SliderGrab]           = col_act;
-	colors[ImGuiCol_SliderGrabActive]     = lighten(col_act, 0.15f);
-	colors[ImGuiCol_Button]               = col_base;
-	colors[ImGuiCol_ButtonHovered]        = lighten(col_base, 0.05f);
-	colors[ImGuiCol_ButtonActive]         = col_act;
-	colors[ImGuiCol_Header]               = col_base;
-	colors[ImGuiCol_HeaderHovered]        = lighten(col_base, 0.05f);
-	colors[ImGuiCol_HeaderActive]         = col_act;
-	colors[ImGuiCol_TextSelectedBg]       = col_sel;
-	colors[ImGuiCol_TableHeaderBg]        = col_base;
+	colors[ImGuiCol_TitleBg]              = col_base;
+	colors[ImGuiCol_TitleBgCollapsed]     = col_base;
+
+	// Frames (input fields, checkboxes, combo boxes)
+	colors[ImGuiCol_FrameBg]              = col_frame;
+	colors[ImGuiCol_FrameBgHovered]       = lighten(col_frame, 0.06f);
+	colors[ImGuiCol_FrameBgActive]        = lighten(col_frame, 0.12f);
+
+	// Borders and separators
+	colors[ImGuiCol_Border]               = col_border;
+	colors[ImGuiCol_BorderShadow]         = lighten(col_base, 0.35f);
+	colors[ImGuiCol_Separator]            = col_border;
+	colors[ImGuiCol_SeparatorHovered]     = lighten(col_border, 0.15f);
+	colors[ImGuiCol_SeparatorActive]      = col_accent;
+
+	// Buttons
+	colors[ImGuiCol_Button]               = col_btn;
+	colors[ImGuiCol_ButtonHovered]        = col_btnhov;
+	colors[ImGuiCol_ButtonActive]         = col_accent;
+
+	// Headers (CollapsingHeader, TreeNode, Selectable, MenuItem)
+	colors[ImGuiCol_Header]               = col_btn;
+	colors[ImGuiCol_HeaderHovered]        = col_btnhov;
+	colors[ImGuiCol_HeaderActive]         = col_accent;
+
+	// Accent elements
+	colors[ImGuiCol_TitleBgActive]        = col_accent;
+	colors[ImGuiCol_CheckMark]            = darken(col_accent, 0.15f);
+	colors[ImGuiCol_SliderGrab]           = col_accent;
+	colors[ImGuiCol_SliderGrabActive]     = lighten(col_accent, 0.15f);
+	colors[ImGuiCol_NavCursor]            = col_accent;
+	colors[ImGuiCol_ResizeGrip]           = darken(col_border, 0.10f);
+	colors[ImGuiCol_ResizeGripHovered]    = col_accent;
+	colors[ImGuiCol_ResizeGripActive]     = lighten(col_accent, 0.10f);
+
+	// Scrollbar
+	colors[ImGuiCol_ScrollbarBg]          = col_frame;
+	colors[ImGuiCol_ScrollbarGrab]        = col_btn;
+	colors[ImGuiCol_ScrollbarGrabHovered] = col_btnhov;
+	colors[ImGuiCol_ScrollbarGrabActive]  = col_accent;
+
+	// Tables
+	colors[ImGuiCol_TableHeaderBg]        = col_tblhdr;
+	colors[ImGuiCol_TableBorderStrong]    = col_border;
+	colors[ImGuiCol_TableBorderLight]     = lighten(col_border, 0.10f);
+	colors[ImGuiCol_TableRowBg]           = ImVec4(0, 0, 0, 0); // transparent
+	colors[ImGuiCol_TableRowBgAlt]        = ImVec4(col_frame.x, col_frame.y, col_frame.z, 0.25f);
+
+	// Tabs
+	colors[ImGuiCol_Tab]                  = col_btn;
+	colors[ImGuiCol_TabHovered]           = col_btnhov;
+	colors[ImGuiCol_TabSelected]          = col_accent;
+	colors[ImGuiCol_TabDimmed]            = darken(col_btn, 0.10f);
+	colors[ImGuiCol_TabDimmedSelected]    = darken(col_accent, 0.20f);
+
+	// Modal
+	colors[ImGuiCol_ModalWindowDimBg]     = col_modal;
 
 	style.FrameBorderSize = 0.0f; // We will draw our own bevels
 	style.WindowBorderSize = 0.0f;
@@ -507,6 +553,93 @@ void apply_imgui_theme()
 	// Add a bit more padding inside windows/child areas
 	style.WindowPadding = ImVec2(10.0f, 10.0f);
 	style.FramePadding = ImVec2(5.0f, 4.0f);
+}
+
+// Deferred font rebuild state — font changes are requested during rendering
+// but applied between frames to avoid modifying the atlas mid-render.
+static bool s_font_rebuild_pending = false;
+// Tracks the font file currently loaded in the atlas.
+static std::string s_loaded_font_file;
+
+void rebuild_gui_fonts()
+{
+	// Mark for rebuild; actual work happens in apply_pending_font_rebuild()
+	s_font_rebuild_pending = true;
+}
+
+static void apply_pending_font_rebuild()
+{
+	if (!s_font_rebuild_pending)
+		return;
+	s_font_rebuild_pending = false;
+
+	ImGuiIO& io = ImGui::GetIO();
+	ImGuiStyle& style = ImGui::GetStyle();
+
+	const float font_px = gui_theme.font_size > 0 ? static_cast<float>(gui_theme.font_size) : 15.0f;
+	const std::string font_file = gui_theme.font_name.empty() ? std::string("AmigaTopaz.ttf") : gui_theme.font_name;
+
+	// Font size: update FontSizeBase for the dynamic atlas to render at.
+	style.FontSizeBase = font_px;
+
+	// Full atlas rebuild needed when the font file changes.
+	// Size changes are handled by FontSizeBase + the dynamic atlas.
+	// Pixel-snap changes require a GUI restart (ImGui's dynamic atlas does
+	// not support changing OversampleH after the font is loaded).
+	const bool needs_rebuild = (font_file != s_loaded_font_file);
+
+	if (needs_rebuild)
+	{
+		const float scaling_factor = DPIHandler::get_layout_scale();
+		const float font_scale_dpi = style.FontScaleDpi;
+		const float font_dpi_scale = (font_scale_dpi > 0.0f) ? (1.0f / font_scale_dpi) : 1.0f;
+		const float font_load_px = font_px * scaling_factor * font_dpi_scale;
+		io.Fonts->Clear();
+
+		const bool use_default_font = (font_file == "AmigaTopaz.ttf");
+		ImFont* loaded_font = nullptr;
+		if (use_default_font) {
+			ImFontConfig pixel_cfg;
+			pixel_cfg.OversampleH = 1;
+			pixel_cfg.PixelSnapH = true;
+			loaded_font = io.Fonts->AddFontFromMemoryCompressedTTF(
+				AmigaTopaz_compressed_data, AmigaTopaz_compressed_size, font_load_px, &pixel_cfg);
+		} else {
+			const std::string font_path = std::filesystem::path(font_file).is_absolute()
+				? font_file
+				: prefix_with_data_path(font_file);
+			if (!font_path.empty() && std::filesystem::exists(font_path)) {
+				loaded_font = io.Fonts->AddFontFromFileTTF(font_path.c_str(), font_load_px);
+			}
+			if (!loaded_font) {
+				ImFontConfig pixel_cfg;
+				pixel_cfg.OversampleH = 1;
+				pixel_cfg.PixelSnapH = true;
+				loaded_font = io.Fonts->AddFontFromMemoryCompressedTTF(
+					AmigaTopaz_compressed_data, AmigaTopaz_compressed_size, font_load_px, &pixel_cfg);
+			}
+		}
+		if (!loaded_font) {
+			ImFontConfig fallback_cfg;
+			fallback_cfg.SizePixels = font_load_px;
+			loaded_font = io.Fonts->AddFontDefault(&fallback_cfg);
+		}
+
+		// Merge icon font
+		{
+			ImFontConfig icons_cfg;
+			icons_cfg.MergeMode = true;
+			icons_cfg.PixelSnapH = true;
+			icons_cfg.GlyphMinAdvanceX = font_load_px;
+			static const ImWchar icon_ranges[] = { ICON_MIN_FA, ICON_MAX_FA, 0 };
+			io.Fonts->AddFontFromMemoryCompressedTTF(
+				fa_solid_900_compressed_data, fa_solid_900_compressed_size,
+				font_load_px, &icons_cfg, icon_ranges);
+		}
+
+		io.FontDefault = loaded_font;
+		s_loaded_font_file = font_file;
+	}
 }
 
 #endif
@@ -1283,20 +1416,29 @@ void amiberry_gui_init()
 
 	ImFont* loaded_font = nullptr;
 	if (use_default_font) {
-		// Load embedded Amiga Topaz — no filesystem dependency
+		// Load embedded Amiga Topaz with pixel-snapping for crisp rendering
+		ImFontConfig pixel_cfg;
+		pixel_cfg.OversampleH = 1;
+		pixel_cfg.PixelSnapH = true;
 		loaded_font = io.Fonts->AddFontFromMemoryCompressedTTF(
-			AmigaTopaz_compressed_data, AmigaTopaz_compressed_size, font_load_px);
+			AmigaTopaz_compressed_data, AmigaTopaz_compressed_size, font_load_px, &pixel_cfg);
 	} else {
 		// User-configured custom font: load from filesystem
-		const std::string font_path = prefix_with_data_path(font_file);
+		// Absolute paths are used directly; relative names go through the data-path prefix
+		const std::string font_path = std::filesystem::path(font_file).is_absolute()
+			? font_file
+			: prefix_with_data_path(font_file);
 		if (!font_path.empty() && std::filesystem::exists(font_path)) {
 			loaded_font = io.Fonts->AddFontFromFileTTF(font_path.c_str(), font_load_px);
 		}
 		if (!loaded_font) {
 			SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION,
 				"ImGui: failed to load font '%s', falling back to embedded Amiga Topaz", font_path.c_str());
+			ImFontConfig pixel_cfg;
+			pixel_cfg.OversampleH = 1;
+			pixel_cfg.PixelSnapH = true;
 			loaded_font = io.Fonts->AddFontFromMemoryCompressedTTF(
-				AmigaTopaz_compressed_data, AmigaTopaz_compressed_size, font_load_px);
+				AmigaTopaz_compressed_data, AmigaTopaz_compressed_size, font_load_px, &pixel_cfg);
 		}
 	}
 	if (!loaded_font) {
@@ -1319,6 +1461,7 @@ void amiberry_gui_init()
 	}
 
 	io.FontDefault = loaded_font;
+	s_loaded_font_file = font_file;
 
 	// Setup Platform/Renderer backends
 #ifdef USE_VULKAN
@@ -1748,7 +1891,13 @@ void run_gui()
 		{
 			ImGui_ImplSDLRenderer3_NewFrame();
 		}
+
 		ImGui_ImplSDL3_NewFrame();
+
+		// Apply deferred font changes after SDL3 NewFrame (window size known)
+		// but before ImGui::NewFrame() (which reads the font atlas).
+		apply_pending_font_rebuild();
+
 		ImGui::NewFrame();
 
 		// While touch-scrolling, suppress hover highlight so items don't
@@ -1940,7 +2089,7 @@ void run_gui()
 				float icon_y = pos.y + (row_total_h - text_h) * 0.5f;
 				ImVec2 icon_size = ImGui::CalcTextSize(categories[i].icon);
 				dl->AddText(ImVec2(pos.x + pad_x, icon_y), icon_col, categories[i].icon);
-				float text_x = pos.x + pad_x + icon_size.x + pad_x;
+				float text_x = pos.x + pad_x + icon_size.x + pad_x * 2.0f;
 				float text_y = pos.y + (row_total_h - text_h) * 0.5f;
 				dl->AddText(ImVec2(text_x, text_y), text_col, categories[i].category);
 			} else if (categories[i].imagepath) {

--- a/src/osdep/imgui/imgui_help_text.h
+++ b/src/osdep/imgui/imgui_help_text.h
@@ -516,6 +516,40 @@ static const char* help_text_sound =
 	"The panel shows an approximate milliseconds-per-buffer value to make this easier to\n"
 	"judge while testing different settings.\n";
 
+static const char* help_text_themes =
+	"The Themes panel allows you to customize the look of the Amiberry GUI.\n"
+	"\n"
+	"Theme selection\n"
+	"Use the Theme dropdown to select a preset. Default and Dark are built-in presets\n"
+	"that are always available. You can also create and select custom themes.\n"
+	"\n"
+	"Font\n"
+	"You can change the font used by the GUI by entering a font filename or selecting\n"
+	"one using the \"...\" file browser button. The font size can also be adjusted.\n"
+	"You can expand the \"System fonts\" section to browse and select from fonts\n"
+	"installed on your system.\n"
+	"Font size changes apply immediately using the +/- buttons.\n"
+	"After changing the font name, click \"Apply font\" to load the new font.\n"
+
+	"\n"
+	"Colors\n"
+	"You can customize the GUI colors, organized by category:\n"
+	"- Window: Window background and input field backgrounds\n"
+	"- Text: Normal and disabled text colors\n"
+	"- Buttons: Button and button hover colors\n"
+	"- Accent: Active/accent color (used for checkmarks, active tabs, sliders)\n"
+	"  and selection highlight\n"
+	"- Borders: Border and separator line colors\n"
+	"- Tables: Table header background\n"
+	"- Overlay: Modal dim color (darkens the screen behind popups)\n"
+	"Color changes are previewed immediately in the GUI.\n"
+	"\n"
+	"Actions\n"
+	"- Use: Apply the current theme as your active theme\n"
+	"- Save: Overwrite the current custom theme file (disabled for built-in presets)\n"
+	"- Save as...: Save the current colors and font under a new theme name\n"
+	"- Reset: Reload the current theme from disk, discarding unsaved changes\n";
+
 static const char* help_text_input =
 	"Here you can select the devices connected to the various input ports.\n"
 	"Port 0 is normally used by a Mouse, while Port 1 is usually for a Joystick.\n"

--- a/src/osdep/imgui/themes.cpp
+++ b/src/osdep/imgui/themes.cpp
@@ -1,0 +1,635 @@
+#include "imgui.h"
+#include <atomic>
+#include <filesystem>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include "sysdeps.h"
+#include "options.h"
+#include "gui/gui_handling.h"
+#include "imgui_panels.h"
+
+#ifdef _MSC_VER
+#define strncasecmp _strnicmp
+#endif
+
+extern std::string get_system_fonts_path();
+
+// Local UI state
+static std::vector<std::string> s_theme_files;
+static int s_selected_theme = -1;
+static bool s_themes_initialized = false;
+static char s_save_as_name[128] = "";
+static bool s_open_save_as_popup = false;
+static bool s_font_changed = false;
+
+// Font input buffer (sized for absolute paths)
+static char s_font_name_buf[512] = "";
+
+static void color_to_float3(const amiberry_gui_color& c, float out[3])
+{
+	out[0] = static_cast<float>(c.r) / 255.0f;
+	out[1] = static_cast<float>(c.g) / 255.0f;
+	out[2] = static_cast<float>(c.b) / 255.0f;
+}
+
+static void float3_to_color(const float in[3], amiberry_gui_color& c)
+{
+	c.r = static_cast<uint8_t>(std::clamp(in[0], 0.0f, 1.0f) * 255.0f + 0.5f);
+	c.g = static_cast<uint8_t>(std::clamp(in[1], 0.0f, 1.0f) * 255.0f + 0.5f);
+	c.b = static_cast<uint8_t>(std::clamp(in[2], 0.0f, 1.0f) * 255.0f + 0.5f);
+}
+
+static bool is_protected_preset(const std::string& name)
+{
+	return name == "Default.theme" || name == "Dark.theme";
+}
+
+static void scan_theme_files()
+{
+	s_theme_files.clear();
+
+	// Protected presets always first
+	s_theme_files.emplace_back("Default.theme");
+	s_theme_files.emplace_back("Dark.theme");
+
+	const std::string themes_dir = get_themes_path();
+	if (!themes_dir.empty() && std::filesystem::exists(themes_dir))
+	{
+		std::vector<std::string> custom;
+		for (const auto& entry : std::filesystem::directory_iterator(themes_dir))
+		{
+			if (!entry.is_regular_file()) continue;
+			const auto ext = entry.path().extension().string();
+			if (ext != ".theme") continue;
+			const auto fname = entry.path().filename().string();
+			if (is_protected_preset(fname)) continue;
+			custom.push_back(fname);
+		}
+		std::sort(custom.begin(), custom.end());
+		for (auto& f : custom)
+			s_theme_files.push_back(std::move(f));
+	}
+}
+
+static void select_theme_by_name(const std::string& name)
+{
+	for (int i = 0; i < static_cast<int>(s_theme_files.size()); i++)
+	{
+		if (s_theme_files[i] == name)
+		{
+			s_selected_theme = i;
+			return;
+		}
+	}
+	s_selected_theme = 0;
+}
+
+static void load_selected_theme()
+{
+	if (s_selected_theme < 0 || s_selected_theme >= static_cast<int>(s_theme_files.size()))
+		return;
+
+	const auto& name = s_theme_files[s_selected_theme];
+	if (name == "Default.theme")
+	{
+		const std::string path = get_themes_path() + name;
+		if (std::filesystem::exists(path))
+			load_theme(name);
+		else
+			load_default_theme();
+	}
+	else if (name == "Dark.theme")
+	{
+		const std::string path = get_themes_path() + name;
+		if (std::filesystem::exists(path))
+			load_theme(name);
+		else
+			load_default_dark_theme();
+	}
+	else
+	{
+		load_theme(name);
+	}
+
+	apply_imgui_theme();
+	rebuild_gui_fonts();
+
+	// Sync font input buffer
+	strncpy(s_font_name_buf, gui_theme.font_name.c_str(), sizeof(s_font_name_buf) - 1);
+	s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
+	s_font_changed = false;
+}
+
+struct FontEntry {
+	std::string full_path;
+	std::string display_name; // cached basename
+};
+
+static std::vector<FontEntry> enumerate_system_fonts()
+{
+	std::vector<std::string> dirs;
+
+	const std::string sys_path = get_system_fonts_path();
+	if (!sys_path.empty())
+		dirs.push_back(sys_path);
+
+#ifdef __APPLE__
+	dirs.emplace_back("/System/Library/Fonts");
+	dirs.emplace_back("/Library/Fonts");
+	const char* home = getenv("HOME");
+	if (home)
+		dirs.push_back(std::string(home) + "/Library/Fonts");
+#elif defined(__ANDROID__)
+	dirs.emplace_back("/system/fonts");
+#elif !defined(_WIN32)
+	// Linux / FreeBSD
+	dirs.emplace_back("/usr/share/fonts");
+	dirs.emplace_back("/usr/local/share/fonts");
+	const char* home = getenv("HOME");
+	if (home)
+	{
+		dirs.push_back(std::string(home) + "/.local/share/fonts");
+		dirs.push_back(std::string(home) + "/.fonts");
+	}
+#endif
+
+	std::vector<std::string> paths;
+	for (const auto& dir : dirs)
+	{
+		if (!std::filesystem::exists(dir)) continue;
+		try
+		{
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(
+				dir, std::filesystem::directory_options::skip_permission_denied))
+			{
+				if (!entry.is_regular_file()) continue;
+				const auto ext = entry.path().extension().string();
+				if (ext == ".ttf" || ext == ".otf" || ext == ".ttc" ||
+					ext == ".TTF" || ext == ".OTF" || ext == ".TTC")
+				{
+					paths.push_back(entry.path().string());
+				}
+			}
+		}
+		catch (const std::filesystem::filesystem_error&) {}
+	}
+
+	// Deduplicate and build display names
+	std::sort(paths.begin(), paths.end());
+	paths.erase(std::unique(paths.begin(), paths.end()), paths.end());
+
+	std::vector<FontEntry> result;
+	result.reserve(paths.size());
+	for (auto& p : paths)
+	{
+		std::string name = std::filesystem::path(p).filename().string();
+		result.push_back({std::move(p), std::move(name)});
+	}
+	return result;
+}
+
+static bool case_insensitive_contains(const std::string& haystack, const char* needle)
+{
+	const size_t needle_len = strlen(needle);
+	if (needle_len == 0) return true;
+	if (needle_len > haystack.size()) return false;
+	for (size_t i = 0; i + needle_len <= haystack.size(); i++)
+	{
+		if (strncasecmp(haystack.c_str() + i, needle, needle_len) == 0)
+			return true;
+	}
+	return false;
+}
+
+// Background font enumeration state
+static std::atomic<bool> s_font_enum_running{false};
+static std::atomic<bool> s_font_enum_done{false};
+static std::mutex s_font_enum_mutex;
+static std::vector<FontEntry> s_font_enum_result;
+
+static void start_font_enumeration()
+{
+	if (s_font_enum_running.load())
+		return;
+	s_font_enum_running.store(true);
+	s_font_enum_done.store(false);
+
+	std::thread([]() {
+		auto result = enumerate_system_fonts();
+		{
+			std::lock_guard<std::mutex> lock(s_font_enum_mutex);
+			s_font_enum_result = std::move(result);
+		}
+		s_font_enum_done.store(true);
+		s_font_enum_running.store(false);
+	}).detach();
+}
+
+void render_panel_themes()
+{
+	// Track the persisted theme name so we can detect external changes
+	// (e.g. the dark-theme toggle in the Misc panel).
+	static char s_synced_theme[128] = "";
+
+	if (!s_themes_initialized)
+	{
+		scan_theme_files();
+		select_theme_by_name(amiberry_options.gui_theme);
+		strncpy(s_font_name_buf, gui_theme.font_name.c_str(), sizeof(s_font_name_buf) - 1);
+		s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
+		s_font_changed = false;
+		strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
+		s_themes_initialized = true;
+	}
+
+	// Re-sync if another panel changed the active theme
+	if (strcmp(s_synced_theme, amiberry_options.gui_theme) != 0)
+	{
+		strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
+		// Only rescan the directory if the new theme isn't already in the list
+		bool found = false;
+		for (int i = 0; i < static_cast<int>(s_theme_files.size()); i++)
+		{
+			if (s_theme_files[i] == amiberry_options.gui_theme)
+			{ found = true; break; }
+		}
+		if (!found)
+			scan_theme_files();
+		select_theme_by_name(amiberry_options.gui_theme);
+		strncpy(s_font_name_buf, gui_theme.font_name.c_str(), sizeof(s_font_name_buf) - 1);
+		s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
+		s_font_changed = false;
+	}
+
+	ImGui::Indent(4.0f);
+
+	// ========== Theme Selection ==========
+	BeginGroupBox("Theme selection");
+
+	ImGui::AlignTextToFramePadding();
+	ImGui::Text("Theme:");
+	ImGui::SameLine();
+	ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x * 2);
+
+	const char* current_label = (s_selected_theme >= 0 && s_selected_theme < static_cast<int>(s_theme_files.size()))
+		? s_theme_files[s_selected_theme].c_str() : "Default.theme";
+
+	if (ImGui::BeginCombo("##ThemeCombo", current_label))
+	{
+		for (int i = 0; i < static_cast<int>(s_theme_files.size()); i++)
+		{
+			ImGui::PushID(i);
+			const bool is_selected = (s_selected_theme == i);
+			if (ImGui::Selectable(s_theme_files[i].c_str(), is_selected))
+			{
+				s_selected_theme = i;
+				load_selected_theme();
+			}
+			if (is_selected)
+				ImGui::SetItemDefaultFocus();
+			ImGui::PopID();
+		}
+		ImGui::EndCombo();
+	}
+	AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), ImGui::IsItemActivated());
+
+	EndGroupBox("Theme selection");
+
+	ImGui::Spacing();
+
+	// ========== Font ==========
+	BeginGroupBox("Font");
+
+	ImGui::AlignTextToFramePadding();
+	ImGui::Text("Font:");
+	ImGui::SameLine();
+
+	const float browse_btn_w = SMALL_BUTTON_WIDTH;
+	const float font_input_w = ImGui::GetContentRegionAvail().x - browse_btn_w - ImGui::GetStyle().ItemSpacing.x;
+	ImGui::SetNextItemWidth(font_input_w);
+	if (AmigaInputText("##FontName", s_font_name_buf, sizeof(s_font_name_buf)))
+	{
+		gui_theme.font_name = s_font_name_buf;
+		s_font_changed = true;
+	}
+	ImGui::SameLine();
+	if (AmigaButton("...##FontBrowse", ImVec2(browse_btn_w, 0)))
+	{
+		std::string start_dir = get_system_fonts_path();
+		if (start_dir.empty() || !std::filesystem::exists(start_dir))
+			start_dir = ".";
+		OpenFileDialogKey("THEMES_FONT_FILE", "Select Font",
+			"Font files (*.ttf *.otf *.ttc){.ttf,.otf,.ttc}", start_dir);
+	}
+	{
+		std::string font_result;
+		if (ConsumeFileDialogResultKey("THEMES_FONT_FILE", font_result))
+		{
+			if (!font_result.empty())
+			{
+				strncpy(s_font_name_buf, font_result.c_str(), sizeof(s_font_name_buf) - 1);
+				s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
+				gui_theme.font_name = font_result;
+				s_font_changed = true;
+			}
+		}
+	}
+
+	ImGui::AlignTextToFramePadding();
+	ImGui::Text("Size:");
+	ImGui::SameLine();
+	{
+		const int old_size = gui_theme.font_size;
+		if (AmigaButton("-##FontDec") && gui_theme.font_size > 8)
+			gui_theme.font_size--;
+		ImGui::SameLine();
+		ImGui::Text("%d", gui_theme.font_size);
+		ImGui::SameLine();
+		if (AmigaButton("+##FontInc") && gui_theme.font_size < 32)
+			gui_theme.font_size++;
+		if (gui_theme.font_size != old_size)
+			rebuild_gui_fonts();
+	}
+
+	if (s_font_changed)
+	{
+		ImGui::SameLine();
+		if (AmigaButton(ICON_FA_CHECK " Apply font"))
+		{
+			rebuild_gui_fonts();
+			s_font_changed = false;
+		}
+	}
+
+
+
+	// System fonts (collapsible, with search and recessed scroll area)
+	static std::vector<FontEntry> s_system_fonts;
+	static bool s_fonts_ready = false;
+	static char s_font_search[128] = "";
+	if (ImGui::TreeNode("System fonts"))
+	{
+		// Kick off background enumeration on first expand
+		if (!s_fonts_ready && !s_font_enum_running.load() && !s_font_enum_done.load())
+			start_font_enumeration();
+
+		// Collect results when background thread finishes
+		if (!s_fonts_ready && s_font_enum_done.load())
+		{
+			std::lock_guard<std::mutex> lock(s_font_enum_mutex);
+			s_system_fonts = std::move(s_font_enum_result);
+			s_fonts_ready = true;
+		}
+
+		if (s_font_enum_running.load())
+		{
+			ImGui::TextDisabled("Scanning system fonts...");
+		}
+		else if (s_system_fonts.empty())
+		{
+			ImGui::TextDisabled("No system fonts found");
+		}
+		else
+		{
+			// Search row
+			ImGui::AlignTextToFramePadding();
+			ImGui::Text("Search:");
+			ImGui::SameLine();
+			const float clear_btn_w = SMALL_BUTTON_WIDTH;
+			ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - clear_btn_w - ImGui::GetStyle().ItemSpacing.x);
+			AmigaInputText("##FontSearch", s_font_search, sizeof(s_font_search));
+			ImGui::SameLine();
+			const bool search_empty = (s_font_search[0] == '\0');
+			if (search_empty) ImGui::BeginDisabled();
+			if (AmigaButton(ICON_FA_XMARK "##ClearFontSearch", ImVec2(clear_btn_w, 0)))
+				s_font_search[0] = '\0';
+			if (search_empty) ImGui::EndDisabled();
+
+			const bool has_filter = (s_font_search[0] != '\0');
+
+			// Count visible fonts for the label (single pass)
+			int visible_count = 0;
+			if (!has_filter)
+				visible_count = static_cast<int>(s_system_fonts.size());
+			else
+				for (const auto& fe : s_system_fonts)
+					if (case_insensitive_contains(fe.display_name, s_font_search))
+						visible_count++;
+			ImGui::Text("%d / %d fonts", visible_count, static_cast<int>(s_system_fonts.size()));
+
+			// Recessed scroll area
+			const float list_height = std::min(200.0f, std::max(80.0f, ImGui::GetContentRegionAvail().y * 0.35f));
+			ImGui::BeginChild("##SystemFontsList", ImVec2(0, list_height));
+			ImGui::Indent(4.0f);
+
+			for (const auto& fe : s_system_fonts)
+			{
+				if (has_filter && !case_insensitive_contains(fe.display_name, s_font_search))
+					continue;
+
+				ImGui::PushID(fe.full_path.c_str());
+				if (ImGui::Selectable(fe.display_name.c_str(), false))
+				{
+					strncpy(s_font_name_buf, fe.full_path.c_str(), sizeof(s_font_name_buf) - 1);
+					s_font_name_buf[sizeof(s_font_name_buf) - 1] = '\0';
+					gui_theme.font_name = fe.full_path;
+					s_font_changed = true;
+				}
+				if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("%s", fe.full_path.c_str());
+				ImGui::PopID();
+			}
+
+			ImGui::Unindent(4.0f);
+			ImGui::EndChild();
+			// Draw recessed bevel around the scroll area
+			const ImVec2 list_min = ImGui::GetItemRectMin();
+			const ImVec2 list_max = ImGui::GetItemRectMax();
+			AmigaBevel(ImVec2(list_min.x - 1, list_min.y - 1),
+				ImVec2(list_max.x + 1, list_max.y + 1), true);
+		}
+		ImGui::TreePop();
+	}
+
+	EndGroupBox("Font");
+
+	ImGui::Spacing();
+
+	// ========== Colors ==========
+	BeginGroupBox("Colors");
+
+	const ImGuiColorEditFlags color_flags = ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_NoAlpha;
+	bool color_changed = false;
+
+	auto ColorRow = [&](const char* label, amiberry_gui_color& color) {
+		float col[3];
+		color_to_float3(color, col);
+		ImGui::AlignTextToFramePadding();
+		if (ImGui::ColorEdit3(label, col, color_flags))
+		{
+			float3_to_color(col, color);
+			color_changed = true;
+		}
+	};
+
+	if (ImGui::BeginTable("##ColorGroups", 2, ImGuiTableFlags_None))
+	{
+		ImGui::TableSetupColumn("Left", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+		ImGui::TableSetupColumn("Right", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Window");
+		ColorRow("Window background", gui_theme.base_color);
+		ColorRow("Input fields", gui_theme.frame_color);
+
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Text");
+		ColorRow("Text", gui_theme.font_color);
+		ColorRow("Text disabled", gui_theme.text_disabled_color);
+
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Buttons");
+		ColorRow("Button", gui_theme.button_color);
+		ColorRow("Button hover", gui_theme.button_hover_color);
+
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Accent");
+		ColorRow("Active / accent", gui_theme.selector_active);
+		ColorRow("Selection highlight", gui_theme.selection_color);
+
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Borders");
+		ColorRow("Border / separator", gui_theme.border_color);
+
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Tables");
+		ColorRow("Table header", gui_theme.table_header_color);
+
+		ImGui::TableNextRow();
+		ImGui::TableNextColumn();
+		ImGui::SeparatorText("Overlay");
+		ColorRow("Modal dim", gui_theme.modal_dim_color);
+
+		ImGui::EndTable();
+	}
+
+	if (color_changed)
+		apply_imgui_theme();
+
+	EndGroupBox("Colors");
+
+	ImGui::Spacing();
+
+	// ========== Actions ==========
+	const auto& current_theme = (s_selected_theme >= 0 && s_selected_theme < static_cast<int>(s_theme_files.size()))
+		? s_theme_files[s_selected_theme] : s_theme_files[0];
+	const bool is_protected = is_protected_preset(current_theme);
+
+	if (AmigaButton(ICON_FA_CHECK " Use", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
+	{
+		strncpy(amiberry_options.gui_theme, current_theme.c_str(),
+			sizeof(amiberry_options.gui_theme) - 1);
+		amiberry_options.gui_theme[sizeof(amiberry_options.gui_theme) - 1] = '\0';
+		strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
+		save_amiberry_settings();
+	}
+	ShowHelpMarker("Apply the current theme as the active theme");
+
+	ImGui::SameLine();
+	if (is_protected) ImGui::BeginDisabled();
+	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
+	{
+		save_theme(current_theme);
+	}
+	if (is_protected) ImGui::EndDisabled();
+	ShowHelpMarker("Overwrite the current custom theme file");
+
+	ImGui::SameLine();
+	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save as...", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
+	{
+		s_save_as_name[0] = '\0';
+		s_open_save_as_popup = true;
+	}
+	ShowHelpMarker("Save the current colors and font as a new theme file");
+
+	ImGui::SameLine();
+	if (AmigaButton(ICON_FA_ARROW_ROTATE_LEFT " Reset", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
+	{
+		load_selected_theme(); // already calls rebuild_gui_fonts() internally
+	}
+	ShowHelpMarker("Reload the current theme from disk, discarding any unsaved changes");
+
+	// Save As popup
+	if (s_open_save_as_popup)
+	{
+		ImGui::OpenPopup("Save Theme As");
+		s_open_save_as_popup = false;
+	}
+	if (ImGui::BeginPopupModal("Save Theme As", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+	{
+		ImGui::Text("Theme name:");
+		AmigaInputText("##SaveAsName", s_save_as_name, sizeof(s_save_as_name));
+
+		ImGui::Spacing();
+		const bool name_empty = (s_save_as_name[0] == '\0');
+		std::string save_filename = s_save_as_name;
+		// Ensure .theme suffix
+		if (save_filename.size() < 7 || save_filename.substr(save_filename.size() - 6) != ".theme")
+			save_filename += ".theme";
+		// Reject names that are just the extension or have no stem
+		const auto stem = std::filesystem::path(save_filename).stem().string();
+		const bool name_no_stem = stem.empty() || stem == ".theme";
+
+		const bool name_protected = is_protected_preset(save_filename);
+		const bool name_has_path_sep = save_filename.find('/') != std::string::npos
+			|| save_filename.find('\\') != std::string::npos
+			|| save_filename.find("..") != std::string::npos;
+		const bool name_invalid = name_empty || name_no_stem || name_protected || name_has_path_sep;
+
+		if (name_invalid) ImGui::BeginDisabled();
+		if (AmigaButton(ICON_FA_FLOPPY_DISK " Save", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
+		{
+			save_theme(save_filename);
+
+			// Only persist if the file was actually written
+			const std::string saved_path = get_themes_path() + save_filename;
+			if (std::filesystem::exists(saved_path))
+			{
+				strncpy(amiberry_options.gui_theme, save_filename.c_str(),
+					sizeof(amiberry_options.gui_theme) - 1);
+				amiberry_options.gui_theme[sizeof(amiberry_options.gui_theme) - 1] = '\0';
+				strncpy(s_synced_theme, amiberry_options.gui_theme, sizeof(s_synced_theme) - 1); s_synced_theme[sizeof(s_synced_theme) - 1] = '\0';
+				save_amiberry_settings();
+
+				scan_theme_files();
+				select_theme_by_name(save_filename);
+			}
+
+			ImGui::CloseCurrentPopup();
+		}
+		if (name_invalid) ImGui::EndDisabled();
+
+		if (name_protected)
+		{
+			ImGui::SameLine();
+			ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "Cannot overwrite built-in presets");
+		}
+		if (name_has_path_sep)
+		{
+			ImGui::SameLine();
+			ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "Name must not contain path separators");
+		}
+
+		ImGui::SameLine();
+		if (AmigaButton(ICON_FA_XMARK " Cancel", ImVec2(BUTTON_WIDTH, BUTTON_HEIGHT)))
+			ImGui::CloseCurrentPopup();
+
+		ImGui::EndPopup();
+	}
+}


### PR DESCRIPTION
Closes #1916

## Summary

Restores the Themes configuration panel that was present in the old Guisan-based GUI, now implemented as a Dear ImGui panel.

## What's included

- **Theme selection** — Dropdown with protected Default/Dark presets and custom `.theme` file discovery from the themes directory
- **Font controls** — System font browser with search, manual path entry via file picker, and live font/size changes using ImGui's v1.92 dynamic font atlas
- **Color editor** — All 7 GUI theme color fields (`base`, `background`, `foreground`, `font`, `selection`, `selector_active`, `selector_inactive`) with `ColorEdit3` and immediate preview via `apply_imgui_theme()`
- **Actions** — Use (persist), Save (custom themes only), Save As (with name validation), Reset (reload from disk)
- **Cross-panel sync** — Detects when the Misc panel dark-theme toggle changes the active theme and re-syncs selection state
- **Absolute font paths** — Custom font loading now supports absolute system-font paths while preserving relative bundled-font fallback
- **Sidebar spacing** — Added extra padding between icons and text labels

## Files changed

| File | Change |
|------|--------|
| `src/osdep/imgui/themes.cpp` | New panel implementation |
| `cmake/SourceFiles.cmake` | Added themes.cpp to build |
| `src/osdep/gui/gui_handling.h` | Panel registration + `rebuild_gui_fonts()` declaration |
| `src/osdep/gui/main_window.cpp` | Deferred font rebuild, absolute path support, sidebar spacing |
| `src/osdep/imgui/imgui_help_text.h` | Help text for Themes panel |

## Testing

Manually tested on macOS:
- Theme switching (Default/Dark/custom)
- Live color preview
- Font name and size changes (immediate via dynamic atlas)
- Save As with protected preset rejection
- Reset to loaded theme state
- Cross-panel sync with Misc dark-theme toggle
- System font enumeration and search filtering