### PR TITLE
fix: disable debug option in libretro makefile

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -97,11 +97,11 @@ endif
 ifeq ($(DEBUG), 1)
    FLAGS += -O0 -g -fno-omit-frame-pointer
 else
-   FLAGS += -O3 -g -DNDEBUG
+   FLAGS += -O3 -DNDEBUG
 endif
 
 ifeq ($(SANITIZE), 1)
-   FLAGS += -fsanitize=address -fno-omit-frame-pointer
+   FLAGS += -fsanitize=address -fno-omit-frame-pointer -g
    LDFLAGS += -fsanitize=address
 endif
 


### PR DESCRIPTION
Fixes # Size of libretro core

Changes proposed in this pull request:
- disable debug option when DEBUG=0

@midwan
