### PR TITLE
fix: gfx window lifecycle bugs and macOS Spaces switching

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -147,6 +147,9 @@ float vsync_vblank, vsync_hblank;
 bool beamracer_debug;
 bool gfx_hdr;
 
+// TODO: These are WinUAE stubs. With threaded Vulkan rendering, surface
+// lifecycle in doInit should be protected if concurrent access is possible.
+// Currently mitigated by skipping surface recreation when dimensions match.
 void gfx_lock()
 {
 }
@@ -565,13 +568,13 @@ static uae_u8* gfx_lock_picasso2(int monid, bool fullupdate)
 uae_u8* gfx_lock_picasso(const int monid, bool fullupdate)
 {
 	struct AmigaMonitor* mon = &AMonitors[monid];
-	static uae_u8* p;
 	if (mon->rtg_locked) {
-		return p;
+		return mon->rtg_locked_ptr;
 	}
-	p = gfx_lock_picasso2(monid, fullupdate);
+	uae_u8* p = gfx_lock_picasso2(monid, fullupdate);
 	if (p) {
 		mon->rtg_locked = true;
+		mon->rtg_locked_ptr = p;
 	}
 	return p;
 }
@@ -645,8 +648,8 @@ bool vsync_switchmode(const int monid, int hz)
 		return true;
 	}
 
-	static struct PicassoResolution* oldmode;
-	static int oldhz;
+	static struct PicassoResolution* oldmode[MAX_AMIGAMONITORS];
+	static int oldhz[MAX_AMIGAMONITORS];
 	int w = mon->currentmode.native_width;
 	int h = mon->currentmode.native_height;
 	struct MultiDisplay* md = getdisplay(&currprefs, monid);
@@ -713,10 +716,10 @@ bool vsync_switchmode(const int monid, int hz)
 			}
 		}
 	}
-	if (found == oldmode && hz == oldhz)
+	if (found == oldmode[monid] && hz == oldhz[monid])
 		return true;
-	oldmode = found;
-	oldhz = hz;
+	oldmode[monid] = found;
+	oldhz[monid] = hz;
 	if (!found) {
 		changed_prefs.gfx_apmode[APMODE_NATIVE].gfx_vsync = 0;
 		if (currprefs.gfx_apmode[APMODE_NATIVE].gfx_vsync != changed_prefs.gfx_apmode[APMODE_NATIVE].gfx_vsync) {
@@ -1511,15 +1514,16 @@ void auto_crop_image()
 			cw, ch, cx, cy, hres, vres, is_ntsc, vblank_hz, width, height, renderer->crop_aspect);
 		rq = { dx, dy, width, height };
 		cr = { cx, cy, cw, ch };
-		if (amiga_surface) {
+		SDL_Surface* surface = get_amiga_surface(0);
+		if (surface) {
 			if (cr.x < 0) cr.x = 0;
 			if (cr.y < 0) cr.y = 0;
-			if (cr.x >= amiga_surface->w) cr.x = 0;
-			if (cr.y >= amiga_surface->h) cr.y = 0;
-			if (cr.w <= 0 || cr.x + cr.w > amiga_surface->w)
-				cr.w = amiga_surface->w - cr.x;
-			if (cr.h <= 0 || cr.y + cr.h > amiga_surface->h)
-				cr.h = amiga_surface->h - cr.y;
+			if (cr.x >= surface->w) cr.x = 0;
+			if (cr.y >= surface->h) cr.y = 0;
+			if (cr.w <= 0 || cr.x + cr.w > surface->w)
+				cr.w = surface->w - cr.x;
+			if (cr.h <= 0 || cr.y + cr.h > surface->h)
+				cr.h = surface->h - cr.y;
 		}
 
 		if (vkbd_allowed(0))

--- a/src/osdep/amiberry_gfx.h
+++ b/src/osdep/amiberry_gfx.h
@@ -114,6 +114,7 @@ struct AmigaMonitor {
 	int screen_is_initialized;
 	int scalepicasso;
 	bool rtg_locked;
+	uae_u8* rtg_locked_ptr;
 	int p96_double_buffer_firstx, p96_double_buffer_lastx;
 	int p96_double_buffer_first, p96_double_buffer_last;
 	int p96_double_buffer_needs_flushing;

--- a/src/osdep/display_modes.cpp
+++ b/src/osdep/display_modes.cpp
@@ -729,6 +729,8 @@ void sortdisplays()
 
 	md = Displays;
 	while (md->monitorname) {
+		// Free previous allocation (from enumeratedisplays2) before replacing
+		xfree(md->DisplayModes);
 		md->DisplayModes = xcalloc(struct PicassoResolution, MAX_PICASSO_MODES);
 
 		write_log(_T("%s '%s' [%s]\n"), md->adaptername, md->adapterid, md->adapterkey);

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -89,7 +89,7 @@ void close_hwnds(struct AmigaMonitor* mon)
 	IRenderer* renderer_to_use = nullptr;
 		if (mon->monitor_id > 0 && mon->renderer) {
 			renderer_to_use = mon->renderer.get();
-		} else if (mon->monitor_id == 00 && g_renderer) {
+		} else if (mon->monitor_id == 0 && g_renderer) {
 		 renderer_to_use = g_renderer.get();
         }
 
@@ -685,7 +685,28 @@ static int create_windows(struct AmigaMonitor* mon)
 			}
 		}
 
-		if (w != nw || h != nh || x != nx || y != ny) {
+		// For fullwindow mode, skip the resize/reposition cycle if the window
+		// is already fullscreen on the correct display. On macOS,
+		// SDL_GetWindowPosition on a fullscreen window may return coordinates
+		// that don't match SDL_GetDisplayBounds (e.g. Space-relative vs global),
+		// causing a false mismatch that triggers SDL_SetWindowFullscreen toggling
+		// — which produces a visible Spaces switching animation.
+		bool needs_resize = (w != nw || h != nh || x != nx || y != ny);
+		if (needs_resize && fullwindow) {
+			SDL_WindowFlags wflags = SDL_GetWindowFlags(mon->amiga_window);
+			if (wflags & SDL_WINDOW_FULLSCREEN) {
+				// Window is already fullscreen — check if it's on the right display
+				SDL_DisplayID current_display = SDL_GetDisplayForWindow(mon->amiga_window);
+				SDL_DisplayID target_display = md ? md->display_id : current_display;
+				if (current_display == target_display) {
+					// Already fullscreen on the correct display, skip the toggle
+					needs_resize = false;
+					write_log(_T("fullwindow: skipping resize — already fullscreen on target display\n"));
+				}
+			}
+		}
+
+		if (needs_resize) {
 			w = nw;
 			h = nh;
 			x = nx;
@@ -1067,43 +1088,56 @@ bool doInit(AmigaMonitor* mon)
 
 	IRenderer* renderer = get_renderer(mon->monitor_id);
 		if (renderer) {
-			int ctx_attempts = 0;
-			bool ctx_success = false;
-
-			while (ctx_attempts < 2 && !ctx_success) {
-				if (!renderer->set_context_attributes(ctx_attempts))
-				{
-					write_log("Failed to set context attributes for mode %d\n", ctx_attempts);
-					ctx_attempts++;
-					continue;
-				}
-
+			// Quick reopen path: if the window already exists and the renderer
+			// context is still valid, skip the expensive destroy/recreate cycle.
+			// This avoids tearing down the GL context or Vulkan surface/swapchain
+			// on resolution-only changes, which on macOS triggers the Spaces
+			// switching animation in fullwindow mode.
+			if (mon->amiga_window && renderer->has_context()) {
 				if (!create_windows(mon))
 				{
 					close_hwnds(mon);
 					return false;
 				}
+			} else {
+				int ctx_attempts = 0;
+				bool ctx_success = false;
 
-				renderer = get_renderer(mon->monitor_id);
-				
-				renderer->destroy_shaders();
-				renderer->destroy_context();
+				while (ctx_attempts < 2 && !ctx_success) {
+					if (!renderer->set_context_attributes(ctx_attempts))
+					{
+						write_log("Failed to set context attributes for mode %d\n", ctx_attempts);
+						ctx_attempts++;
+						continue;
+					}
 
-				if (renderer->init_context(mon->amiga_window))
-				{
-					ctx_success = true;
+					if (!create_windows(mon))
+					{
+						close_hwnds(mon);
+						return false;
+					}
+
+					renderer = get_renderer(mon->monitor_id);
+
+					renderer->destroy_shaders();
+					renderer->destroy_context();
+
+					if (renderer->init_context(mon->amiga_window))
+					{
+						ctx_success = true;
+					}
+					else
+					{
+						write_log("Renderer context init failed for mode %d on monitor %d. Retrying...\n", ctx_attempts, mon->monitor_id);
+						close_windows(mon);
+						ctx_attempts++;
+					}
 				}
-				else
-				{
-					write_log("Renderer context init failed for mode %d on monitor %d. Retrying...\n", ctx_attempts, mon->monitor_id);
-					close_windows(mon);
-					ctx_attempts++;
-				}
-			}
 
-			if (!ctx_success) {
-				write_log("All renderer context attempts failed for monitor %d. Aborting doInit.\n", mon->monitor_id);
-				return false;
+				if (!ctx_success) {
+					write_log("All renderer context attempts failed for monitor %d. Aborting doInit.\n", mon->monitor_id);
+					return false;
+				}
 			}
 		} else {
 			if (!create_windows(mon))
@@ -1159,17 +1193,20 @@ bool doInit(AmigaMonitor* mon)
 
 	// For secondary monitors, use per-monitor surface instead of global
 	SDL_Surface*& surface_ref = (mon->monitor_id > 0) ? mon->amiga_surface : amiga_surface;
-	if (surface_ref)
+	if (!surface_ref || surface_ref->w != display_width || surface_ref->h != display_height || surface_ref->format != pixel_format)
 	{
-		SDL_DestroySurface(surface_ref);
-		surface_ref = nullptr;
+		if (surface_ref)
+		{
+			SDL_DestroySurface(surface_ref);
+			surface_ref = nullptr;
+		}
+		surface_ref = SDL_CreateSurface(display_width, display_height, pixel_format);
+		if (!surface_ref) {
+			write_log("Failed to create amiga_surface for monitor %d: %s\n", mon->monitor_id, SDL_GetError());
+			return false;
+		}
+		update_system_pixel_format();
 	}
-	surface_ref = SDL_CreateSurface(display_width, display_height, pixel_format);
-	if (!surface_ref) {
-		write_log("Failed to create amiga_surface for monitor %d: %s\n", mon->monitor_id, SDL_GetError());
-		return false;
-	}
-	update_system_pixel_format();
 
 	updatewinrect(mon, true);
 	mon->screen_is_initialized = 1;

--- a/src/osdep/sdl_renderer.cpp
+++ b/src/osdep/sdl_renderer.cpp
@@ -131,7 +131,7 @@ bool SDLRenderer::alloc_texture(int monid, int w, int h)
 		SDL_DestroyTexture(m_amiga_texture);
 
 	AmigaMonitor* mon = &AMonitors[monid];
-	m_amiga_texture = SDL_CreateTexture(mon->amiga_renderer, pixel_format, SDL_TEXTUREACCESS_STREAMING, amiga_surface->w, amiga_surface->h);
+	m_amiga_texture = SDL_CreateTexture(mon->amiga_renderer, pixel_format, SDL_TEXTUREACCESS_STREAMING, w, h);
 	if (m_amiga_texture != nullptr)
 	{
 		SDL_SetTextureBlendMode(m_amiga_texture, SDL_BLENDMODE_NONE);
@@ -342,7 +342,7 @@ void SDLRenderer::render_onscreen_joystick(int monid)
 
 void SDLRenderer::present_frame(int monid, int mode)
 {
-	if (gfx_platform_present_frame(amiga_surface)) {
+	if (gfx_platform_present_frame(get_amiga_surface(monid))) {
 		return;
 	}
 


### PR DESCRIPTION
## Summary

Fix macOS Spaces animation triggered by auto-crop/resolution autoswitch in fullwindow mode, plus several related gfx subsystem bugs found during code review.

## macOS Spaces Fix

**Problem:** In fullwindow mode on macOS, every auto-resolution or auto-crop change triggers a visible Spaces switching animation — the desktop briefly flashes as macOS transitions between Spaces.

**Root cause:** Two issues compound:

1. **`create_windows()` false mismatch:** `SDL_GetWindowPosition()` on a macOS fullscreen window returns coordinates that don't match `SDL_GetDisplayBounds()` (Space-relative vs global). This falsely triggers the `SDL_SetWindowFullscreen(false)` → resize → `SDL_SetWindowFullscreen(true)` cycle on every resolution change, even though the window is already correctly positioned.

2. **`doInit()` unconditional context teardown:** The renderer context (GL context or entire Vulkan stack) was destroyed and recreated on every `doInit()` call, even when the window already existed with a valid context.

**Fix:**
- Skip the fullscreen toggle in `create_windows()` when the window is already fullscreen on the correct display (checked via `SDL_GetWindowFlags` + `SDL_GetDisplayForWindow`)
- Skip renderer context destroy/recreate in `doInit()` when window already exists with valid context
- Guard surface recreation — only destroy/recreate when dimensions or format actually changed

**Platform impact:** The guard only fires when all three conditions are true: (1) position/size mismatch detected, (2) fullwindow mode, (3) window already fullscreen on same display. Safe on all platforms — Linux/KMSDRM/Windows/Android either don't hit the mismatch or benefit from skipping unnecessary fullscreen toggling.

## Bug Fixes

| Bug | Fix |
|-----|-----|
| **DisplayModes memory leak** — `sortdisplays()` overwrote pointer from `enumeratedisplays2()` without freeing | Added `xfree()` before `xcalloc()` |
| **`gfx_lock_picasso` static pointer** shared across all monitors — multi-monitor RTG would return wrong buffer | Replaced with per-monitor `rtg_locked_ptr` field on `AmigaMonitor` |
| **`SDLRenderer::alloc_texture`** ignored `w`/`h` params, always used `amiga_surface` dimensions | Now uses the requested dimensions |
| **`vsync_switchmode`** static `oldmode`/`oldhz` shared across monitors | Replaced with per-monitor arrays |
| **Octal literal typo** `== 00` in `close_hwnds` | Fixed to `== 0` |

## Consistency Improvements

- Replace direct `amiga_surface` references with `get_amiga_surface()` in `auto_crop_image` and `SDLRenderer::present_frame`
- Document empty `gfx_lock()`/`gfx_unlock()` stubs as known gap with threaded Vulkan rendering

## Files Changed

- `src/osdep/gfx_window.cpp` — Spaces fix (context skip + fullwindow guard + surface guard)
- `src/osdep/amiberry_gfx.cpp` — picasso lock fix, vsync arrays, surface accessor, gfx_lock docs
- `src/osdep/amiberry_gfx.h` — Added `rtg_locked_ptr` field
- `src/osdep/display_modes.cpp` — DisplayModes leak fix
- `src/osdep/sdl_renderer.cpp` — alloc_texture dimensions + surface accessor

## Testing

- Verified macOS fullwindow with auto-crop + resolution autoswitch: no more Spaces animation
- Builds clean with both `USE_OPENGL=ON` and `USE_VULKAN=ON` on macOS