### PR TITLE
fix: on-screen joystick does not show in Input list when enabled

### DIFF
--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -1395,12 +1395,6 @@ bool load_custom_options(uae_prefs* p, const std::string& option, const TCHAR* v
 	return false;
 }
 
-void import_joysticks()
-{
-	joystick_inited = 0;
-	init_joystick();
-}
-
 static void close_joystick()
 {
 	if (!joystick_inited)
@@ -1411,6 +1405,12 @@ static void close_joystick()
 	num_joystick = 0;
 	osj_device_index = -1;
 	di_free();
+}
+
+void import_joysticks()
+{
+	close_joystick();
+	init_joystick();
 }
 
 static int acquire_joystick(const int num, int flags)

--- a/src/osdep/gfx_prefs_check.cpp
+++ b/src/osdep/gfx_prefs_check.cpp
@@ -674,6 +674,12 @@ int check_prefs_changed_gfx()
 	if (currprefs.onscreen_joystick != changed_prefs.onscreen_joystick)
 	{
 		currprefs.onscreen_joystick = changed_prefs.onscreen_joystick;
+		// Re-enumerate joysticks so the on-screen joystick device gets
+		// registered or removed from the input subsystem.
+		import_joysticks();
+		inputdevice_config_change();
+		joystick_refresh_needed = true;
+
 		if (currprefs.onscreen_joystick)
 		{
 			AmigaMonitor* mon = &AMonitors[0];

--- a/src/osdep/imgui/virtualkeyboard.cpp
+++ b/src/osdep/imgui/virtualkeyboard.cpp
@@ -3,6 +3,7 @@
 #include "options.h"
 #include "inputdevice.h"
 #include "amiberry_input.h"
+#include "target.h"
 #include <string>
 #include <vector>
 
@@ -69,9 +70,18 @@ void render_panel_virtual_keyboard()
     ImGui::Indent(4.0f);
 
     // On-screen touch joystick (D-pad + fire buttons overlay)
+    bool osj_before = changed_prefs.onscreen_joystick;
     AmigaCheckbox("On-screen Joystick", &changed_prefs.onscreen_joystick);
     if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip("Show virtual D-pad and fire buttons for touchscreen control");
+    }
+    if (changed_prefs.onscreen_joystick != osj_before) {
+        // Apply immediately so the device appears in the Input panel
+        // without waiting for the emulation loop prefs check.
+        currprefs.onscreen_joystick = changed_prefs.onscreen_joystick;
+        import_joysticks();
+        inputdevice_config_change();
+        joystick_refresh_needed = true;
     }
 
     ImGui::Separator();


### PR DESCRIPTION
## Problem

When enabling the on-screen joystick at runtime (e.g. via the Virtual Keyboard panel checkbox), the device was not registered in the input subsystem. It rendered visually but never appeared in the Input device list, making it unusable for touch-only scenarios like Android.

## Root Cause

The on-screen joystick device is registered during `init_joystick()` → `input_platform_init_joystick()`, but **only if `currprefs.onscreen_joystick` is already true** at enumeration time. Since `init_joystick()` runs once at startup (gated by `joystick_inited`), toggling the option later never triggers re-enumeration — `osj_device_index` stays at `-1`, and both `inject_directions()` and `inject_buttons()` silently no-op.

## Fix

Call `import_joysticks()` + `inputdevice_config_change()` when toggling the on-screen joystick preference:
- **Enable path**: re-enumerates before `on_screen_joystick_set_enabled(true)` so the device index is valid for auto-assign
- **Disable path**: re-enumerates after cleanup to remove the device from the input list

Fixes #1927