### PR TITLE
Fix macOS full-window teardown during restart

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -983,7 +983,7 @@ void graphics_leave()
 {
 	for (int i = 0; i < MAX_AMIGAMONITORS; i++)
 	{
-		close_windows(&AMonitors[i]);
+		close_windows(&AMonitors[i], true);
 	}
 	g_renderer.reset();
 }
@@ -1378,7 +1378,7 @@ bool toggle_rtg(const int monid, const int mode)
 void close_rtg(const int monid, const bool reset)
 {
 	struct AmigaMonitor* mon = &AMonitors[monid];
-	close_windows(mon);
+	close_windows(mon, false);
 	if (reset) {
 		struct amigadisplay* ad = &adisplays[monid];
 		mon->screen_is_picasso = false;
@@ -1594,4 +1594,3 @@ void screenshot(int monid, int mode, int doprepare)
 
 	save_thumb(screenshot_filename);
 }
-

--- a/src/osdep/amiberry_gfx.h
+++ b/src/osdep/amiberry_gfx.h
@@ -180,7 +180,7 @@ extern int default_freq;
 
 extern void check_error_sdl(bool check, const char* message);
 extern void toggle_fullscreen();
-extern void close_windows(AmigaMonitor*);
+extern void close_windows(AmigaMonitor*, bool force_destroy_fullwindow);
 extern void reopen_gfx(AmigaMonitor*);
 extern int reopen(AmigaMonitor*, int, bool);
 extern void updatewinfsmode(int monid, uae_prefs* p);

--- a/src/osdep/gfx_prefs_check.cpp
+++ b/src/osdep/gfx_prefs_check.cpp
@@ -414,7 +414,7 @@ int check_prefs_changed_gfx()
 					inputdevice_unacquire();
 					unacquired = true;
 				}
-				close_windows(mon);
+				close_windows(mon, false);
 				if (currprefs.gfx_api != changed_prefs.gfx_api || currprefs.gfx_api_options != changed_prefs.gfx_api_options) {
 					currprefs.gfx_api = changed_prefs.gfx_api;
 					currprefs.gfx_api_options = changed_prefs.gfx_api_options;

--- a/src/osdep/gfx_window.cpp
+++ b/src/osdep/gfx_window.cpp
@@ -70,7 +70,7 @@ static void gfxmode_reset(int monid)
 {
 }
 
-void close_hwnds(struct AmigaMonitor* mon)
+void close_hwnds(struct AmigaMonitor* mon, const bool force_destroy_fullwindow)
 {
 	if (mon->screen_is_initialized)
 		releasecapture(mon);
@@ -87,23 +87,24 @@ void close_hwnds(struct AmigaMonitor* mon)
 		setmouseactive(mon->monitor_id, 0);
 
 	IRenderer* renderer_to_use = nullptr;
-		if (mon->monitor_id > 0 && mon->renderer) {
-			renderer_to_use = mon->renderer.get();
-		} else if (mon->monitor_id == 0 && g_renderer) {
-		 renderer_to_use = g_renderer.get();
-        }
+	if (mon->monitor_id > 0 && mon->renderer) {
+		renderer_to_use = mon->renderer.get();
+	} else if (mon->monitor_id == 0 && g_renderer) {
+		renderer_to_use = g_renderer.get();
+	}
 
+	const bool preserve_fullwindow_window = isfullscreen() < 0 && !force_destroy_fullwindow;
 	if (renderer_to_use) {
 		renderer_to_use->close_hwnds_cleanup(mon);
 		renderer_to_use->destroy_context();
-		if (!kmsdrm_detected && isfullscreen() >= 0) {
+		if (!kmsdrm_detected && !preserve_fullwindow_window) {
 			renderer_to_use->destroy_platform_renderer(mon);
 		}
 	}
 	if (mon->monitor_id > 0 && mon->renderer) {
 		mon->renderer.reset();
 	}
-	if (mon->amiga_window && !kmsdrm_detected && isfullscreen() >= 0)
+	if (mon->amiga_window && !kmsdrm_detected && !preserve_fullwindow_window)
 	{
 #if defined(__ANDROID__)
 		// Reuse existing window
@@ -375,7 +376,7 @@ void reopen_gfx(struct AmigaMonitor* mon)
 
 void open_screen(struct AmigaMonitor* mon)
 {
-	close_windows(mon);
+	close_windows(mon, false);
 	open_windows(mon, true, true);
 }
 
@@ -436,7 +437,7 @@ int reopen(struct AmigaMonitor* mon, int full, bool unacquire)
 	return 0;
 }
 
-void close_windows(struct AmigaMonitor* mon)
+void close_windows(struct AmigaMonitor* mon, const bool force_destroy_fullwindow)
 {
 	if (currprefs.headless) {
 		write_log("Headless mode: Skipping SDL resource cleanup for monitor %d.\n", mon->monitor_id);
@@ -474,15 +475,15 @@ void close_windows(struct AmigaMonitor* mon)
 
 	freevidbuffer(mon->monitor_id, &avidinfo->drawbuffer);
 	freevidbuffer(mon->monitor_id, &avidinfo->tempbuffer);
-	close_hwnds(mon);
+	close_hwnds(mon, force_destroy_fullwindow);
 	mon->active = false;
 }
 
-void close_all_windows()
+void close_all_windows(const bool force_destroy_fullwindow)
 {
 	for (int i = MAX_AMIGAMONITORS - 1; i >= 0; i--) {
 		if (AMonitors[i].active)
-			close_windows(&AMonitors[i]);
+			close_windows(&AMonitors[i], force_destroy_fullwindow);
 	}
 }
 
@@ -918,7 +919,7 @@ static int create_windows(struct AmigaMonitor* mon)
 
 	if (!mon->amiga_window) {
 		write_log(_T("creation of amiga window failed\n"));
-		close_hwnds(mon);
+		close_hwnds(mon, false);
 		return 0;
 	}
 
@@ -927,7 +928,7 @@ static int create_windows(struct AmigaMonitor* mon)
 	if (renderer_to_use) {
 		if (!renderer_to_use->create_platform_renderer(mon)) {
 			write_log(_T("creation of platform renderer failed\n"));
-			close_hwnds(mon);
+			close_hwnds(mon, false);
 			return 0;
 		}
 		if (mon->amiga_renderer) {
@@ -1096,7 +1097,7 @@ bool doInit(AmigaMonitor* mon)
 			if (mon->amiga_window && renderer->has_context()) {
 				if (!create_windows(mon))
 				{
-					close_hwnds(mon);
+					close_hwnds(mon, false);
 					return false;
 				}
 			} else {
@@ -1113,7 +1114,7 @@ bool doInit(AmigaMonitor* mon)
 
 					if (!create_windows(mon))
 					{
-						close_hwnds(mon);
+						close_hwnds(mon, false);
 						return false;
 					}
 
@@ -1129,7 +1130,7 @@ bool doInit(AmigaMonitor* mon)
 					else
 					{
 						write_log("Renderer context init failed for mode %d on monitor %d. Retrying...\n", ctx_attempts, mon->monitor_id);
-						close_windows(mon);
+						close_windows(mon, false);
 						ctx_attempts++;
 					}
 				}
@@ -1142,7 +1143,7 @@ bool doInit(AmigaMonitor* mon)
 		} else {
 			if (!create_windows(mon))
 			{
-				close_hwnds(mon);
+				close_hwnds(mon, false);
 				return false;
 			}
 		}

--- a/src/osdep/gfx_window.h
+++ b/src/osdep/gfx_window.h
@@ -13,9 +13,9 @@
 struct AmigaMonitor;
 
 // Window lifecycle
-void close_hwnds(struct AmigaMonitor* mon);
-void close_windows(struct AmigaMonitor* mon);
-void close_all_windows();
+void close_hwnds(struct AmigaMonitor* mon, bool force_destroy_fullwindow);
+void close_windows(struct AmigaMonitor* mon, bool force_destroy_fullwindow);
+void close_all_windows(bool force_destroy_fullwindow);
 int open_windows(AmigaMonitor* mon, bool mousecapture, bool started);
 void open_screen(struct AmigaMonitor* mon);
 void reopen_gfx(struct AmigaMonitor* mon);

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -3465,7 +3465,7 @@ void picasso_enablescreen(int monid, int on)
 			write_log(_T("picasso_enablescreen: Failed to create window for monitor %d\n"), monid);
 		}
 	} else if (monid > 0 && !on && AMonitors[monid].active) {
-		close_windows(&AMonitors[monid]);
+		close_windows(&AMonitors[monid], false);
 	}
 #endif
 
@@ -7252,4 +7252,3 @@ uae_u8 *save_p96 (size_t *len, uae_u8 *dstptr)
 }
 
 #endif
-


### PR DESCRIPTION
## Summary
- add explicit full-window teardown control to the SDL window lifecycle helpers
- preserve full-window windows during normal graphics reopens, but force a real destroy during full shutdown/restart
- thread the explicit teardown mode through the affected graphics and RTG callers

## Why
macOS full-window mode intentionally preserved the SDL window to avoid flicker and Spaces animations during normal graphics reopens. That same preservation path was also used during full teardown, which let the old fullscreen Space window survive a restart and get reused on the next launch.

## Impact
This fixes the frozen old macOS Space window seen after restarting from the GUI in full-window mode, while keeping the existing no-flicker behavior for normal mode switches and resolution changes.

## Root Cause
The full-window preservation logic in `close_hwnds()` and `close_windows()` only looked at the current fullscreen mode. It did not distinguish between a normal in-process graphics reopen and a true shutdown/restart path.

## Validation
- `cmake --build cmake-build-debug -j8`

Refs #1930.