### PR TITLE
Fix macOS intel JIT would crash on startup

### DIFF
--- a/packaging/macos/Amiberry.entitlements
+++ b/packaging/macos/Amiberry.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
 </dict>
 </plist>

--- a/src/jit/x86/compemu_support_x86.cpp
+++ b/src/jit/x86/compemu_support_x86.cpp
@@ -720,9 +720,9 @@ static void flush_icache_none(int);
 //void (*flush_icache)(int) = flush_icache_none;
 
 #ifdef UAE
-static void disable_jit_on_runtime_alloc_failure(const char *what)
+void disable_jit_on_runtime_alloc_failure(const char *what)
 {
-	if (!cache_enabled)
+	if (!cache_enabled && currprefs.cachesize == 0 && changed_prefs.cachesize == 0)
 		return;
 
 	write_log("JIT: WARNING: %s\n", what);
@@ -4185,7 +4185,27 @@ void alloc_cache(void)
 			cache_size /= 2;
 		}
 	}
-	vm_protect(compiled_code, cache_size * 1024, VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE);
+	if (!compiled_code)
+		return;
+	if (!vm_protect(compiled_code, cache_size * 1024,
+		VM_PAGE_READ | VM_PAGE_WRITE | VM_PAGE_EXECUTE)) {
+#if defined(__APPLE__)
+		disable_jit_on_runtime_alloc_failure(
+			"Could not make the x86 JIT cache executable. "
+			"Signed macOS Intel builds need the "
+			"com.apple.security.cs.allow-unsigned-executable-memory entitlement.");
+#else
+		disable_jit_on_runtime_alloc_failure(
+			"Could not make the x86 JIT cache executable.");
+#endif
+		vm_release(compiled_code, cache_size * 1024);
+		compiled_code = 0;
+#if defined(CPU_x86_64)
+		vm_acquire_anchor = NULL;
+#endif
+		cache_size = 0;
+		return;
+	}
 	
 	if (compiled_code) {
 		jit_log("<JIT compiler> : actual translation cache size : %d KB at %p-%p", cache_size, compiled_code, compiled_code + cache_size*1024);

--- a/src/jit/x86/compemu_x86.h
+++ b/src/jit/x86/compemu_x86.h
@@ -180,6 +180,9 @@ extern void (*flush_icache)(int);
 #endif
 extern void alloc_cache(void);
 extern int check_for_cache_miss(void);
+#ifdef UAE
+extern void disable_jit_on_runtime_alloc_failure(const char *what);
+#endif
 
 /* JIT FPU compilation */
 struct jit_disable_opcodes {

--- a/src/jit/x86/exception_handler.cpp
+++ b/src/jit/x86/exception_handler.cpp
@@ -975,7 +975,13 @@ static void install_exception_handler(void)
 		 * JIT allocator to place it near .data/JIT cache, then set RWX. */
 		veccode = (uae_u8 *) jit_vm_acquire(256, 0);
 		if (veccode) {
-			uae_vm_protect(veccode, 256, UAE_VM_READ_WRITE_EXECUTE);
+			if (!uae_vm_protect(veccode, 256, UAE_VM_READ_WRITE_EXECUTE)) {
+				disable_jit_on_runtime_alloc_failure(
+					"Could not make the x86 exception trampoline executable.");
+				uae_vm_free(veccode, 256);
+				veccode = NULL;
+				return;
+			}
 		} else {
 			write_log("JIT: FATAL: veccode allocation failed -- "
 				"cannot install exception handler, disabling JIT\n");


### PR DESCRIPTION
**Description**

  This fixes a startup crash reported on macOS Intel for 8.1.3, where the same app/config worked on Apple Silicon but was killed shortly after launch on Intel.

  **Root cause**

  The Apple Silicon and Intel JIT paths are different on macOS:

  - ARM64 uses the dedicated MAP_JIT path, which is compatible with the existing com.apple.security.cs.allow-jit entitlement.
  - The legacy x86 JIT still uses classic executable-memory transitions (mprotect(..., PROT_EXEC) / RWX-style setup) for the translation cache and helper stubs.

  On signed hardened-runtime Intel builds, that path was denied by macOS. The Intel log showed mprotect / mmap permission failures during x86 JIT initialization, and the Apple crash report
  ended with:

  - EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))

  **What changed**

  - Added com.apple.security.cs.allow-unsigned-executable-memory to the non-App-Store macOS entitlements.
  - Hardened the x86 JIT startup path so that if executable page setup fails, Amiberry disables JIT and falls back to the interpreter instead of continuing with a broken JIT state.
  - Added the same fallback handling for the x86 exception trampoline setup.

  **Why this is safe**

  - The entitlement change is macOS-only and applies to the release bundle that is codesigned in the macOS packaging workflow.
  - Linux and Windows are unaffected in the success path.
  - On non-macOS x86 platforms, the only behavior change is improved failure handling if executable memory setup ever fails: JIT is disabled cleanly instead of proceeding into undefined
    behavior.
