### PR TITLE
Fix relative filesystem and hardfile config paths

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -5448,6 +5448,9 @@ static int cfgfile_parse_newfilesys (struct uae_prefs *p, int nr, int type, TCHA
 			*tmpp++ = 0;
 			_tcscpy (uci.rootdir, tmpp2);
 		}
+		str = cfgfile_subst_path_load(UNEXPANDED, &p->path_hardfile, uci.rootdir, true);
+		if (str)
+			_tcscpy(uci.rootdir, str);
 		_tcscpy (uci.volname, volname);
 		_tcscpy (uci.devname, devname);
 		if (! getintval (&tmpp, &uci.bootpri, 0))
@@ -5491,8 +5494,14 @@ static int cfgfile_parse_newfilesys (struct uae_prefs *p, int nr, int type, TCHA
 			}
 			tmpp += tmppr - tmppr2;
 		}
-		if (uci.rootdir[0] != ':')
+		if (uci.rootdir[0] != ':') {
+			if (type == 1 || type == 4) {
+				str = cfgfile_subst_path_load(UNEXPANDED, &p->path_hardfile, uci.rootdir, false);
+				if (str)
+					_tcscpy(uci.rootdir, str);
+			}
 			get_hd_geometry (&uci);
+		}
 		_tcscpy (uci.devname, devname);
 		if (! getintval (&tmpp, &uci.sectors, ',')
 			|| ! getintval (&tmpp, &uci.surfaces, ',')
@@ -5738,7 +5747,9 @@ static int cfgfile_parse_filesys (struct uae_prefs *p, const TCHAR *option, TCHA
 				goto invalid_fs;
 			_tcscpy (uci.rootdir, value);
 		}
-		str = cfgfile_subst_path_load (UNEXPANDED, &p->path_hardfile, uci.rootdir, true);
+		str = cfgfile_subst_path_load (UNEXPANDED, &p->path_hardfile, uci.rootdir, hdf ? false : true);
+		if (str)
+			_tcscpy (uci.rootdir, str);
 		if (uci.geometry[0])
 			parse_geo(uci.geometry, &uci, nullptr, false, false);
 #ifdef FILESYS


### PR DESCRIPTION
Fixes #1955.

## Summary
This fixes relative-path handling for mounted directories and HDFs loaded from config files.

## Problem
Amiberry was already attempting to resolve filesystem/hardfile paths through `cfgfile_subst_path_load(...)`, but in the relevant parser paths the resolved result was not written back into `uci.rootdir`.

That meant relative config entries could still fail at runtime, even when equivalent ROM path handling worked.

## This showed up in practice with configs such as:
- `filesystem2=rw,DH2:Shared:./Harddrives/Shared,0`
- `hardfile2=rw,DH0:./Harddrives/AmigaVision.hdf,...`
- legacy `filesystem=` / `hardfile=` entries using relative paths

## Fix
Copy the resolved path back into `uci.rootdir` in:
- `cfgfile_parse_newfilesys()` for `filesystem2` directory mounts
- `cfgfile_parse_newfilesys()` for HDF-backed mounts
- `cfgfile_parse_filesys()` for legacy `filesystem` / `hardfile` entries

The change is intentionally narrow and does not reroute CD or tape handling through `hardfile_path`.

## Why this helps
It makes mounted directories and HDFs behave consistently with the existing path-resolution logic instead of discarding the resolved path during parsing.

## Testing
I have not been able to do a full local build/run verification in this environment, since I don’t have the full build setup at the moment, sorry about that!

Relevant commit
- `e79192b0` - `Fix relative filesystem and hardfile config paths`

@midwan
