### PR TITLE
Fix CD image dialog default browse path

### DIFF
--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4854,6 +4854,28 @@ std::string get_cdrom_path()
 	return fix_trailing(cdrom_path);
 }
 
+static std::string get_first_valid_multipath_entry(const multipath& paths)
+{
+	for (const auto& path : paths.path)
+	{
+		if (path[0] != '\0' && _tcscmp(path, _T("./")) != 0 && _tcscmp(path, _T(".\\")) != 0)
+			return path;
+	}
+
+	return {};
+}
+
+std::string get_cdrom_browse_path()
+{
+	auto path = get_first_valid_multipath_entry(changed_prefs.path_cd);
+	if (path.empty())
+		path = get_first_valid_multipath_entry(currprefs.path_cd);
+	if (!path.empty())
+		return path;
+
+	return get_cdrom_path();
+}
+
 void set_cdrom_path(const std::string& newpath)
 {
 	cdrom_path = newpath;
@@ -5478,6 +5500,8 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 	TCHAR option[CONFIG_BLEN], value[CONFIG_BLEN];
 	int numROMs, numDisks, numCDs;
 	char tmpFile[MAX_DPATH];
+	TCHAR legacy_cd_path[MAX_DPATH];
+	TCHAR legacy_cd_path_option[CONFIG_BLEN];
 	int ret = 0;
 	std::string configured_base_path;
 
@@ -5522,6 +5546,7 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 	}
 	else
 	{
+		_sntprintf(legacy_cd_path_option, sizeof legacy_cd_path_option / sizeof(TCHAR), _T("%s.cd_path"), TARGET_NAME);
 		ret |= cfgfile_string(option, value, "config_path", config_path);
 		ret |= cfgfile_string(option, value, "controllers_path", controllers_path);
 		ret |= cfgfile_string(option, value, "retroarch_config", retroarch_file);
@@ -5530,6 +5555,12 @@ static int parse_amiberry_settings_line(const char *path, char *linea)
 		ret |= cfgfile_string(option, value, "floppy_path", floppy_path);
 		ret |= cfgfile_string(option, value, "harddrive_path", harddrive_path);
 		ret |= cfgfile_string(option, value, "cdrom_path", cdrom_path);
+		if (cfgfile_string(option, value, _T("cd_path"), legacy_cd_path, sizeof legacy_cd_path)
+			|| cfgfile_string(option, value, legacy_cd_path_option, legacy_cd_path, sizeof legacy_cd_path))
+		{
+			cdrom_path = legacy_cd_path;
+			ret = 1;
+		}
 		ret |= cfgfile_string(option, value, "logfile_path", logfile_path);
 		ret |= cfgfile_string(option, value, "rom_path", rom_path);
 		ret |= cfgfile_string(option, value, "rp9_path", rp9_path);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4876,6 +4876,45 @@ std::string get_cdrom_browse_path()
 	return get_cdrom_path();
 }
 
+static std::string resolve_cdrom_relative_path(const multipath& paths, const std::filesystem::path& relativePath)
+{
+	for (const auto& basePath : paths.path)
+	{
+		if (basePath[0] == '\0' || _tcscmp(basePath, _T("./")) == 0 || _tcscmp(basePath, _T(".\\")) == 0)
+			continue;
+
+		std::error_code ec;
+		const auto candidate = std::filesystem::path(basePath) / relativePath;
+		if (std::filesystem::exists(candidate, ec))
+			return candidate.string();
+
+		const auto parent = candidate.parent_path();
+		ec.clear();
+		if (!parent.empty() && std::filesystem::is_directory(parent, ec))
+			return candidate.string();
+	}
+
+	return {};
+}
+
+std::string get_cdrom_browse_path(const std::string& currentPath)
+{
+	if (currentPath.empty())
+		return get_cdrom_browse_path();
+
+	const std::filesystem::path path(currentPath);
+	if (path.is_absolute())
+		return currentPath;
+
+	auto resolved = resolve_cdrom_relative_path(changed_prefs.path_cd, path);
+	if (resolved.empty())
+		resolved = resolve_cdrom_relative_path(currprefs.path_cd, path);
+	if (!resolved.empty())
+		return resolved;
+
+	return get_cdrom_browse_path();
+}
+
 void set_cdrom_path(const std::string& newpath)
 {
 	cdrom_path = newpath;

--- a/src/osdep/amiberry_gui.cpp
+++ b/src/osdep/amiberry_gui.cpp
@@ -705,7 +705,7 @@ void disk_selection(const int shortcut, uae_prefs* prefs)
 		if (prefs->cdslots[0].inuse && strlen(prefs->cdslots[0].name) > 0)
 			tmp = std::string(prefs->cdslots[0].name);
 		else
-			tmp = get_cdrom_path();
+			tmp = get_cdrom_browse_path();
 
 		if (!tmp.empty())
 		{

--- a/src/osdep/file_dialog.cpp
+++ b/src/osdep/file_dialog.cpp
@@ -3,6 +3,7 @@
 
 #include <cfloat>
 #include <cctype>
+#include <filesystem>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -216,10 +217,39 @@ namespace
 #endif
 	}
 
+	static std::string resolve_dialog_initial_directory(const std::string& initialPath)
+	{
+		if (initialPath.empty())
+			return {};
+
+		std::error_code ec;
+		std::filesystem::path path(initialPath);
+
+		if (std::filesystem::is_directory(path, ec))
+			return path.string();
+
+		ec.clear();
+		if (std::filesystem::exists(path, ec))
+		{
+			const auto parent = path.parent_path();
+			return parent.empty() ? path.string() : parent.string();
+		}
+
+		const auto parent = path.parent_path();
+		if (!parent.empty())
+		{
+			ec.clear();
+			if (std::filesystem::is_directory(parent, ec))
+				return parent.string();
+		}
+
+		return initialPath;
+	}
+
 	static void open_igfd_file_dialog(const char* key, const char* title, const char* filters, const std::string& initialPath)
 	{
 		IGFD::FileDialogConfig config;
-		config.path = initialPath;
+		config.path = resolve_dialog_initial_directory(initialPath);
 		config.countSelectionMax = 1;
 		config.flags = ImGuiFileDialogFlags_Modal;
 		ImGuiFileDialog::Instance()->OpenDialog(key, title, filters, config);
@@ -228,7 +258,7 @@ namespace
 	static void open_igfd_dir_dialog(const char* key, const std::string& initialPath)
 	{
 		IGFD::FileDialogConfig config;
-		config.path = initialPath;
+		config.path = resolve_dialog_initial_directory(initialPath);
 		config.countSelectionMax = 1;
 		config.flags = ImGuiFileDialogFlags_Modal;
 		ImGuiFileDialog::Instance()->OpenDialog(key, "Choose Directory", nullptr, config);
@@ -307,6 +337,7 @@ void OpenFileDialogKey(const char* key, const char* title, const char* filters, 
 	key = dialog_key_or_default(key);
 	title = title ? title : "Choose File";
 	filters = filters ? filters : ".*";
+	const auto dialogPath = resolve_dialog_initial_directory(initialPath);
 
 	if (can_use_native_dialog())
 	{
@@ -330,7 +361,7 @@ void OpenFileDialogKey(const char* key, const char* title, const char* filters, 
 				args.filterList = parsed.items.data();
 				args.filterCount = static_cast<nfdfiltersize_t>(parsed.items.size());
 			}
-			args.defaultPath = initialPath.empty() ? nullptr : initialPath.c_str();
+			args.defaultPath = dialogPath.empty() ? nullptr : dialogPath.c_str();
 			args.parentWindow = parentWindow;
 			result = NFD_SaveDialogU8_With(&outPath, &args);
 		}
@@ -342,7 +373,7 @@ void OpenFileDialogKey(const char* key, const char* title, const char* filters, 
 				args.filterList = parsed.items.data();
 				args.filterCount = static_cast<nfdfiltersize_t>(parsed.items.size());
 			}
-			args.defaultPath = initialPath.empty() ? nullptr : initialPath.c_str();
+			args.defaultPath = dialogPath.empty() ? nullptr : dialogPath.c_str();
 			args.parentWindow = parentWindow;
 			result = NFD_OpenDialogU8_With(&outPath, &args);
 		}
@@ -403,13 +434,14 @@ bool IsFileDialogOpenKey(const char* key)
 void OpenDirDialogKey(const char* key, const std::string& initialPath)
 {
 	key = dialog_key_or_default(key);
+	const auto dialogPath = resolve_dialog_initial_directory(initialPath);
 
 	if (can_use_native_dialog())
 	{
 #ifdef HAS_NFD
 		ensure_wayland_display();
 		nfdpickfolderu8args_t args{};
-		args.defaultPath = initialPath.empty() ? nullptr : initialPath.c_str();
+		args.defaultPath = dialogPath.empty() ? nullptr : dialogPath.c_str();
 
 		AmigaMonitor* mon = &AMonitors[0];
 		if (mon->gui_window)

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -150,6 +150,14 @@ static void AddToMruCdList(const std::string& path)
         lstMRUCDList.resize(10);
 }
 
+static std::string GetCdImageBrowseStartPath(const std::string& currentPath)
+{
+    if (!currentPath.empty() && !IsCdDevicePath(currentPath))
+        return currentPath;
+
+    return get_cdrom_path();
+}
+
 // Helper to handle TCHAR arrays in ImGui
 static bool InputTextT(const char* label, TCHAR* buf, size_t buf_size, ImGuiInputTextFlags flags = 0)
 {
@@ -496,14 +504,9 @@ static void RenderCDSection()
     ImGui::SameLine();
     if (AmigaButton("...")) {
          char* curr_path = ua(changed_prefs.cdslots[0].name);
-         std::string startPath = curr_path;
-         if (startPath.empty()) {
-             char* tmp = ua(get_cdrom_path().c_str());
-             startPath = tmp;
-             xfree(tmp);
-         }
+         const std::string startPath = GetCdImageBrowseStartPath(curr_path);
          xfree(curr_path);
-         OpenFileDialogKey("HD_CD_SLOT", "Select CD image file", "CD Images (*.cue,*.iso,*.ccd,*.mds,*.chd,*.nrg){.cue,.iso,.ccd,.mds,.chd,.nrg},All Files (*){.*}", get_cdrom_path());
+         OpenFileDialogKey("HD_CD_SLOT", "Select CD image file", "CD Images (*.cue,*.iso,*.ccd,*.mds,*.chd,*.nrg){.cue,.iso,.ccd,.mds,.chd,.nrg},All Files (*){.*}", startPath);
     }
     
     ImGui::EndDisabled();
@@ -1218,7 +1221,7 @@ static void ShowEditCDDriveModal()
         AmigaBevel(ImGui::GetItemRectMin(), ImGui::GetItemRectMax(), true);
         ImGui::SameLine();
         if (AmigaButton("...")) {
-            OpenFileDialogKey("HD_CD_MODAL", "Select CD Image", "CD Images (*.cue,*.iso,*.ccd,*.mds,*.chd,*.nrg){.cue,.iso,.ccd,.mds,.chd,.nrg},All Files (*){.*}", get_cdrom_path());
+            OpenFileDialogKey("HD_CD_MODAL", "Select CD Image", "CD Images (*.cue,*.iso,*.ccd,*.mds,*.chd,*.nrg){.cue,.iso,.ccd,.mds,.chd,.nrg},All Files (*){.*}", GetCdImageBrowseStartPath(path_buf));
             selecting_cd_modal_image = true;
         }
 

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -152,10 +152,10 @@ static void AddToMruCdList(const std::string& path)
 
 static std::string GetCdImageBrowseStartPath(const std::string& currentPath)
 {
-    if (!currentPath.empty() && !IsCdDevicePath(currentPath))
-        return currentPath;
+    if (IsCdDevicePath(currentPath))
+        return get_cdrom_browse_path();
 
-    return get_cdrom_browse_path();
+    return get_cdrom_browse_path(currentPath);
 }
 
 // Helper to handle TCHAR arrays in ImGui

--- a/src/osdep/imgui/hd.cpp
+++ b/src/osdep/imgui/hd.cpp
@@ -155,7 +155,7 @@ static std::string GetCdImageBrowseStartPath(const std::string& currentPath)
     if (!currentPath.empty() && !IsCdDevicePath(currentPath))
         return currentPath;
 
-    return get_cdrom_path();
+    return get_cdrom_browse_path();
 }
 
 // Helper to handle TCHAR arrays in ImGui

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -493,7 +493,7 @@ void render_panel_quickstart() {
             std::string tmp;
             if (std::strlen(changed_prefs.cdslots[0].name) > 0 &&
                 std::strncmp(changed_prefs.cdslots[0].name, "/dev/", 5) != 0)
-                tmp = changed_prefs.cdslots[0].name;
+                tmp = get_cdrom_browse_path(changed_prefs.cdslots[0].name);
             else
                 tmp = get_cdrom_browse_path();
 

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -495,7 +495,7 @@ void render_panel_quickstart() {
                 std::strncmp(changed_prefs.cdslots[0].name, "/dev/", 5) != 0)
                 tmp = changed_prefs.cdslots[0].name;
             else
-                tmp = get_cdrom_path();
+                tmp = get_cdrom_browse_path();
 
             OpenFileDialogKey("QUICKSTART", "Select CD image file", "CD Images (*.cue,*.bin,*.iso,*.ccd,*.mds,*.chd,*.nrg){.cue,.bin,.iso,.ccd,.mds,.chd,.nrg},All Files (*){.*}", tmp);
             qs_pending_cd = true;

--- a/src/osdep/imgui/quickstart.cpp
+++ b/src/osdep/imgui/quickstart.cpp
@@ -491,7 +491,8 @@ void render_panel_quickstart() {
         const float cd_button_width = BUTTON_WIDTH * 1.33f;
         if (AmigaButton(ICON_FA_FOLDER_OPEN " Select file", ImVec2(cd_button_width, 0))) {
             std::string tmp;
-            if (std::strlen(changed_prefs.cdslots[0].name) > 0)
+            if (std::strlen(changed_prefs.cdslots[0].name) > 0 &&
+                std::strncmp(changed_prefs.cdslots[0].name, "/dev/", 5) != 0)
                 tmp = changed_prefs.cdslots[0].name;
             else
                 tmp = get_cdrom_path();

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -171,6 +171,7 @@ extern std::string get_harddrive_path();
 extern void set_harddrive_path(const std::string& newpath);
 extern std::string get_cdrom_path();
 extern std::string get_cdrom_browse_path();
+extern std::string get_cdrom_browse_path(const std::string& currentPath);
 extern void set_cdrom_path(const std::string& newpath);
 extern std::string get_themes_path();
 extern std::string get_shaders_path();

--- a/src/osdep/target.h
+++ b/src/osdep/target.h
@@ -170,6 +170,7 @@ extern void set_floppy_path(const std::string& newpath);
 extern std::string get_harddrive_path();
 extern void set_harddrive_path(const std::string& newpath);
 extern std::string get_cdrom_path();
+extern std::string get_cdrom_browse_path();
 extern void set_cdrom_path(const std::string& newpath);
 extern std::string get_themes_path();
 extern std::string get_shaders_path();


### PR DESCRIPTION
## Summary
- normalize file-dialog start paths to a directory before handing them to native or ImGui file pickers
- reuse the current CD image path in the HD panel instead of discarding it
- avoid using /dev/... device paths as the starting folder for CD image browsing

## Root cause
The CD image picker was feeding the dialog layer raw file paths in some flows and, in the HD panel, computing a better start path but still opening from the configured CD-ROM directory. Native Linux dialogs expect a folder for defaultPath, so passing a file path can make them fall back to the desktop or $HOME instead of the configured CD path.

## Validation
- CLion targeted rebuild of src/osdep/file_dialog.cpp, src/osdep/imgui/hd.cpp, and src/osdep/imgui/quickstart.cpp
- cmake --build build -j8

Closes #1952
