### PR TITLE
Fix .uaem timestamp updates after file writes

### DIFF
--- a/src/filesys.cpp
+++ b/src/filesys.cpp
@@ -6236,6 +6236,15 @@ static void	action_set_date(TrapContext *ctx, Unit *unit, dpacket *packet)
 		//write_log (_T("%llu.%u (%d,%d,%d) %s\n"), tv.tv_sec, tv.tv_usec, trap_get_long(ctx, date), trap_get_long(ctx, date + 4), trap_get_long(ctx, date + 8), a->nname);
 		if (!my_utime (a->nname, &tv))
 			err = dos_errno ();
+		else {
+			for (Key *k = unit->keys; k; k = k->next) {
+				if (!k->fd || k->fd->fstype != FS_DIRECTORY || !k->fd->of
+					|| !k->aino || !k->aino->nname || _tcscmp(k->aino->nname, a->nname) != 0) {
+					continue;
+				}
+				my_set_time_explicit(k->fd->of);
+			}
+		}
 	}
 	if (err != 0) {
 		PUT_PCK_RES1 (packet, DOS_FALSE);

--- a/src/include/fsdb.h
+++ b/src/include/fsdb.h
@@ -210,6 +210,7 @@ extern std::string my_get_sha1_of_file(const char* filepath);
 char* fsdb_native_path(const char* root_dir, const char* amiga_path);
 void fsdb_get_file_time(a_inode* node, int* days, int* mins, int* ticks);
 int fsdb_set_file_time(a_inode* node, int days, int mins, int ticks);
+void fsdb_sync_file_time_from_host(const TCHAR* nname);
 int host_errno_to_dos_errno(int err);
 bool copyfile(const char* target, const char* source, bool replace);
 #endif

--- a/src/include/fsdb.h
+++ b/src/include/fsdb.h
@@ -175,6 +175,7 @@ extern uae_s64 my_lseek(struct my_openfile_s* mos, uae_s64 offset, int whence) n
 extern uae_s64 my_fsize (struct my_openfile_s*);
 extern unsigned int my_read (struct my_openfile_s*, void*, unsigned int);
 extern unsigned int my_write (struct my_openfile_s*, void*, unsigned int);
+extern void my_set_time_explicit(struct my_openfile_s*) noexcept;
 extern int my_truncate (const TCHAR *name, uae_u64 len);
 extern int dos_errno (void);
 extern bool my_existslink(const char* name);

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -143,8 +143,9 @@ struct my_opendir_s {
 };
 
 struct my_openfile_s {
-	int fd;
-	char* path;
+	int fd{};
+	char* path{};
+	bool touched{};
 };
 
 #ifdef AMIBERRY
@@ -670,6 +671,17 @@ std::string prefix_with_data_path(const std::string& filename)
 	return t - mktime(&gt);
 }
 
+[[nodiscard]] static long get_mtime_usec(const struct stat& st) noexcept
+{
+#ifdef _WIN32
+	return 0;
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+	return static_cast<long>(st.st_mtimespec.tv_nsec / 1000);
+#else
+	return static_cast<long>(st.st_mtim.tv_nsec / 1000);
+#endif
+}
+
 [[nodiscard]] bool my_stat(const TCHAR* name, struct mystat* statbuf) noexcept
 {
 	try {
@@ -705,7 +717,7 @@ std::string prefix_with_data_path(const std::string& filename)
 		statbuf->mode = ((file_status.permissions() & fs::perms::owner_read) != fs::perms::none ? FILEFLAG_READ : 0) |
 			((file_status.permissions() & fs::perms::owner_write) != fs::perms::none ? FILEFLAG_WRITE : 0);
 		statbuf->mtime.tv_sec = st.st_mtime + get_local_time_offset(st.st_mtime);
-		statbuf->mtime.tv_usec = 0;
+		statbuf->mtime.tv_usec = static_cast<uae_s32>(get_mtime_usec(st));
 
 		return true;
 	}
@@ -931,6 +943,11 @@ struct my_openfile_s* my_open(const TCHAR* name, int flags)
 	}
 
 	mos->path = strdup(name);
+	mos->touched = false;
+	if (flags & O_TRUNC) {
+		mos->touched = true;
+		fsdb_sync_file_time_from_host(mos->path);
+	}
 	return mos.release();
 }
 
@@ -942,6 +959,8 @@ void my_close(struct my_openfile_s* mos)
 
 	if (close(mos->fd) != 0) {
 		write_log("my_close: close on file %s failed: %s\n", mos->path, strerror(errno));
+	} else if (mos->touched) {
+		my_utime(mos->path, nullptr);
 	}
 
 	free(mos->path);
@@ -997,6 +1016,10 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 				continue;
 			}
 
+			if (total_written > 0) {
+				mos->touched = true;
+				fsdb_sync_file_time_from_host(mos->path);
+			}
 			write_log("my_write: write on file %s failed with error %s after %u bytes\n",
 				mos->path, strerror(errno), total_written);
 			return total_written; // Return partial progress on error
@@ -1010,6 +1033,12 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		}
 
 		total_written += static_cast<unsigned int>(bytes_written);
+		mos->touched = true;
+	}
+
+	if (total_written > 0) {
+		mos->touched = true;
+		fsdb_sync_file_time_from_host(mos->path);
 	}
 
 	// Only log if we didn't write everything but didn't hit an error
@@ -1124,6 +1153,8 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 			return -1;
 		}
 
+		mos->touched = true;
+		fsdb_sync_file_time_from_host(mos->path);
 		return 0;
 	}
 	catch (const std::exception& e) {

--- a/src/osdep/amiberry_filesys.cpp
+++ b/src/osdep/amiberry_filesys.cpp
@@ -146,6 +146,7 @@ struct my_openfile_s {
 	int fd{};
 	char* path{};
 	bool touched{};
+	bool explicit_time_set{};
 };
 
 #ifdef AMIBERRY
@@ -944,8 +945,10 @@ struct my_openfile_s* my_open(const TCHAR* name, int flags)
 
 	mos->path = strdup(name);
 	mos->touched = false;
+	mos->explicit_time_set = false;
 	if (flags & O_TRUNC) {
 		mos->touched = true;
+		mos->explicit_time_set = false;
 		fsdb_sync_file_time_from_host(mos->path);
 	}
 	return mos.release();
@@ -960,7 +963,10 @@ void my_close(struct my_openfile_s* mos)
 	if (close(mos->fd) != 0) {
 		write_log("my_close: close on file %s failed: %s\n", mos->path, strerror(errno));
 	} else if (mos->touched) {
-		my_utime(mos->path, nullptr);
+		if (!mos->explicit_time_set && !my_utime(mos->path, nullptr)) {
+			write_log("my_close: failed to update timestamp on file %s\n", mos->path);
+		}
+		fsdb_sync_file_time_from_host(mos->path);
 	}
 
 	free(mos->path);
@@ -992,6 +998,13 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 	return static_cast<unsigned int>(bytes_read);
 }
 
+void my_set_time_explicit(struct my_openfile_s* mos) noexcept
+{
+	if (mos) {
+		mos->explicit_time_set = true;
+	}
+}
+
 [[nodiscard]] unsigned int my_write(struct my_openfile_s* mos, void* b, unsigned int size)
 {
 	// Early validation with combined null check message
@@ -1018,6 +1031,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 
 			if (total_written > 0) {
 				mos->touched = true;
+				mos->explicit_time_set = false;
 				fsdb_sync_file_time_from_host(mos->path);
 			}
 			write_log("my_write: write on file %s failed with error %s after %u bytes\n",
@@ -1034,6 +1048,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 
 		total_written += static_cast<unsigned int>(bytes_written);
 		mos->touched = true;
+		mos->explicit_time_set = false;
 	}
 
 	if (total_written > 0) {
@@ -1154,6 +1169,7 @@ unsigned int my_read(struct my_openfile_s* mos, void* b, unsigned int size)
 		}
 
 		mos->touched = true;
+		mos->explicit_time_set = false;
 		fsdb_sync_file_time_from_host(mos->path);
 		return 0;
 	}

--- a/src/osdep/fsdb_host.cpp
+++ b/src/osdep/fsdb_host.cpp
@@ -471,6 +471,38 @@ int fsdb_write_uaem(const char* nname, const fsdb_file_info* info)
 	return fsdb_write_uaem_internal(nullptr, nname, info);
 }
 
+void fsdb_sync_file_time_from_host(const TCHAR* nname)
+{
+	if (!nname || !currprefs.filesys_custom_uaefsdb) {
+		return;
+	}
+
+	fsdb_file_info info;
+	fsdb_init_file_info(&info);
+	if (fsdb_read_uaem(nname, &info) != 0) {
+		if (info.comment) {
+			xfree(info.comment);
+		}
+		return;
+	}
+
+	struct mystat statbuf {};
+	if (my_stat(nname, &statbuf)) {
+		int days, mins, ticks;
+		timeval_to_amiga(&statbuf.mtime, &days, &mins, &ticks, 50);
+		if (info.days != days || info.mins != mins || info.ticks != ticks) {
+			info.days = days;
+			info.mins = mins;
+			info.ticks = ticks;
+			fsdb_write_uaem_internal(nullptr, nname, &info);
+		}
+	}
+
+	if (info.comment) {
+		xfree(info.comment);
+	}
+}
+
 /* Return nonzero for any name we can't create on the native filesystem.  */
 static int fsdb_name_invalid_2(a_inode* aino, const TCHAR* name, int isDirectory)
 {

--- a/src/osdep/fsdb_host.cpp
+++ b/src/osdep/fsdb_host.cpp
@@ -605,6 +605,7 @@ bool my_utime(const char* name, const struct mytimeval* tv)
 	}
 
 	struct mytimeval mtv;
+	const auto path_utf8 = iso_8859_1_to_utf8(std::string_view(name));
 
 	bool ok = false;
 	try {
@@ -638,11 +639,11 @@ bool my_utime(const char* name, const struct mytimeval* tv)
 		struct _utimbuf utb;
 		utb.actime = mtv.tv_sec;
 		utb.modtime = mtv.tv_sec;
-		ok = _utime(name, &utb) == 0;
+		ok = _utime(path_utf8.c_str(), &utb) == 0;
 #else
 		struct timeval times[2];
 		times[0] = times[1] = { mtv.tv_sec, mtv.tv_usec };
-		ok = utimes(name, times) == 0;
+		ok = utimes(path_utf8.c_str(), times) == 0;
 #endif
 	}
 	catch (...) {


### PR DESCRIPTION
## Summary

Fix host filesystem `.uaem` timestamp handling so Amiga-side file timestamps update correctly after modifying existing files, including files that already have a `.uaem` sidecar and files reopened through output/truncate flows.

## Root Cause

The hostfs metadata path could leave `.uaem` timestamps stale after writes:

- host mtime sub-second data was not being propagated into the emulated stat path
- sidecar timestamp refreshes were not consistently triggered for truncate/write/truncate-like mutation paths
- the final close path could preserve stale metadata instead of authoritatively updating the file timestamp and sidecar together

## What Changed

- add `fsdb_sync_file_time_from_host()` and expose it in `fsdb.h`
- preserve fractional host mtimes in `my_stat()` for platforms that provide them
- track whether an open host file handle actually mutated the file
- refresh `.uaem` metadata during truncate/write/truncate-size operations
- on successful close of a touched file handle, call `my_utime(..., nullptr)` so the host file timestamp and `.uaem` sidecar are updated together

## User Impact

This fixes cases where AmigaDOS `list` continued to show the old timestamp after commands like:

- `echo foo to test`
- `protect test s`
- wait
- `echo bar to test`
- `list test`

It also improves sidecar timestamp precision by carrying host sub-second mtime data into the Amiga 50 Hz tick conversion.

## Validation

- `mcp__clion__build_project` on touched files
- `cmake --build build -j4 --target amiberry`
- manual repro confirmed by the reported Amiga shell workflow after the final close-path fix
