### PR TITLE
Persist filter settings per config

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -999,6 +999,13 @@ struct uae_prefs {
 	int gfx_vertical_offset;
 	int gfx_correct_aspect;
 	int scaling_method;
+#ifdef AMIBERRY
+	char shader[128];
+	char shader_rtg[128];
+	bool use_bezel;
+	bool use_custom_bezel;
+	char custom_bezel[256];
+#endif
 
 	bool gui_alwaysontop;
 	bool main_alwaysontop;

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -4083,6 +4083,14 @@ void target_default_options(uae_prefs* p, const int type)
 	{
 		p->gfx_autoresolution = amiberry_options.default_gfx_autoresolution;
 	}
+
+	_tcscpy(p->shader, amiberry_options.shader[0] ? amiberry_options.shader : _T("none"));
+	_tcscpy(p->shader_rtg, amiberry_options.shader_rtg[0] ? amiberry_options.shader_rtg : _T("none"));
+	_tcscpy(p->custom_bezel, amiberry_options.custom_bezel[0] ? amiberry_options.custom_bezel : _T("none"));
+	p->use_custom_bezel = amiberry_options.use_custom_bezel
+		&& _tcsicmp(p->custom_bezel, _T("none")) != 0;
+	p->use_bezel = p->use_custom_bezel ? false : amiberry_options.use_bezel;
+
 	if (amiberry_options.default_line_mode == 1)
 	{
 		// Double line mode
@@ -4291,6 +4299,11 @@ void target_save_options(zfile* f, uae_prefs* p)
 	cfgfile_target_dwrite(f, _T("kbd_led_scr"), _T("%d"), p->kbd_led_scr);
 	cfgfile_target_dwrite(f, _T("kbd_led_cap"), _T("%d"), p->kbd_led_cap);
 	cfgfile_target_dwrite(f, _T("scaling_method"), _T("%d"), p->scaling_method);
+	cfgfile_target_dwrite_str(f, _T("shader"), p->shader);
+	cfgfile_target_dwrite_str(f, _T("shader_rtg"), p->shader_rtg);
+	cfgfile_target_dwrite_bool(f, _T("use_bezel"), p->use_bezel);
+	cfgfile_target_dwrite_bool(f, _T("use_custom_bezel"), p->use_custom_bezel);
+	cfgfile_target_dwrite_str(f, _T("custom_bezel"), p->custom_bezel);
 
 	cfgfile_target_dwrite_str(f, _T("open_gui"), p->open_gui);
 	cfgfile_target_dwrite_str(f, _T("quit_amiberry"), p->quit_amiberry);
@@ -4445,6 +4458,38 @@ static int target_parse_option_host(uae_prefs *p, const TCHAR *option, const TCH
 		|| cfgfile_string(option, value, "right_amiga", p->right_amiga, sizeof p->right_amiga)
 		|| cfgfile_intval(option, value, _T("cpu_idle"), &p->cpu_idle, 1))
 		return 1;
+
+	if (cfgfile_string(option, value, _T("shader"), p->shader, sizeof p->shader)) {
+		if (!p->shader[0])
+			_tcscpy(p->shader, _T("none"));
+		return 1;
+	}
+
+	if (cfgfile_string(option, value, _T("shader_rtg"), p->shader_rtg, sizeof p->shader_rtg)) {
+		if (!p->shader_rtg[0])
+			_tcscpy(p->shader_rtg, _T("none"));
+		return 1;
+	}
+
+	if (cfgfile_yesno(option, value, _T("use_bezel"), &p->use_bezel)) {
+		if (p->use_bezel)
+			p->use_custom_bezel = false;
+		return 1;
+	}
+
+	if (cfgfile_yesno(option, value, _T("use_custom_bezel"), &p->use_custom_bezel)) {
+		if (p->use_custom_bezel)
+			p->use_bezel = false;
+		return 1;
+	}
+
+	if (cfgfile_string(option, value, _T("custom_bezel"), p->custom_bezel, sizeof p->custom_bezel)) {
+		if (!p->custom_bezel[0] || _tcsicmp(p->custom_bezel, _T("none")) == 0) {
+			_tcscpy(p->custom_bezel, _T("none"));
+			p->use_custom_bezel = false;
+		}
+		return 1;
+	}
 
 	if (cfgfile_yesno(option, value, _T("onscreen_joystick"), &p->onscreen_joystick))
 		return 1;

--- a/src/osdep/gfx_prefs_check.cpp
+++ b/src/osdep/gfx_prefs_check.cpp
@@ -239,6 +239,11 @@ int check_prefs_changed_gfx()
 	c |= currprefs.rtg_hardwaresprite != changed_prefs.rtg_hardwaresprite ? 32 : 0;
 	c |= currprefs.rtg_multithread != changed_prefs.rtg_multithread ? 32 : 0;
 	c |= currprefs.rtg_zerocopy != changed_prefs.rtg_zerocopy ? 32 : 0;
+	c |= _tcscmp(currprefs.shader, changed_prefs.shader) ? 1 : 0;
+	c |= _tcscmp(currprefs.shader_rtg, changed_prefs.shader_rtg) ? 1 : 0;
+	c |= currprefs.use_bezel != changed_prefs.use_bezel ? 1 : 0;
+	c |= currprefs.use_custom_bezel != changed_prefs.use_custom_bezel ? 1 : 0;
+	c |= _tcscmp(currprefs.custom_bezel, changed_prefs.custom_bezel) ? 1 : 0;
 #endif
 
 	if (display_change_requested || c)
@@ -305,6 +310,11 @@ int check_prefs_changed_gfx()
 		}
 		currprefs.gfx_correct_aspect = changed_prefs.gfx_correct_aspect;
 		currprefs.scaling_method = changed_prefs.scaling_method;
+		_tcscpy(currprefs.shader, changed_prefs.shader);
+		_tcscpy(currprefs.shader_rtg, changed_prefs.shader_rtg);
+		currprefs.use_bezel = changed_prefs.use_bezel;
+		currprefs.use_custom_bezel = changed_prefs.use_custom_bezel;
+		_tcscpy(currprefs.custom_bezel, changed_prefs.custom_bezel);
 #endif
 
 		currprefs.rtg_horiz_zoom_mult = changed_prefs.rtg_horiz_zoom_mult;

--- a/src/osdep/imgui/filter.cpp
+++ b/src/osdep/imgui/filter.cpp
@@ -139,10 +139,24 @@ static int find_shader_index(const char* shader_name)
 			return static_cast<int>(i);
 		}
 	}
-	return 2;  // Default to "pc" (index 2)
+	return 0;  // Default to "none"
 }
 
 static bool show_shader_params_popup = false;
+
+static void save_filter_defaults()
+{
+	strncpy(amiberry_options.shader, changed_prefs.shader, sizeof(amiberry_options.shader) - 1);
+	amiberry_options.shader[sizeof(amiberry_options.shader) - 1] = '\0';
+	strncpy(amiberry_options.shader_rtg, changed_prefs.shader_rtg, sizeof(amiberry_options.shader_rtg) - 1);
+	amiberry_options.shader_rtg[sizeof(amiberry_options.shader_rtg) - 1] = '\0';
+	amiberry_options.use_custom_bezel = changed_prefs.use_custom_bezel &&
+		strcmp(changed_prefs.custom_bezel, "none") != 0;
+	amiberry_options.use_bezel = amiberry_options.use_custom_bezel ? false : changed_prefs.use_bezel;
+	strncpy(amiberry_options.custom_bezel, changed_prefs.custom_bezel, sizeof(amiberry_options.custom_bezel) - 1);
+	amiberry_options.custom_bezel[sizeof(amiberry_options.custom_bezel) - 1] = '\0';
+	save_amiberry_settings();
+}
 
 static void render_shader_parameters_popup()
 {
@@ -288,15 +302,16 @@ void render_panel_filter()
 	// Native Shader Selection
 	BeginGroupBox("Native Display Shader");
 	{
-		int native_idx = find_shader_index(amiberry_options.shader);
+		int native_idx = find_shader_index(changed_prefs.shader);
 		const float native_label_w = ImGui::CalcTextSize("Shader for native Amiga modes").x;
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - native_label_w - spacing * 3);
 		if (ImGui::BeginCombo("##NativeShader", shader_items[native_idx])) {
 			for (int i = 0; i < static_cast<int>(shader_items.size()); i++) {
 				bool is_selected = (i == native_idx);
 				if (ImGui::Selectable(shader_items[i], is_selected)) {
-					strncpy(amiberry_options.shader, shader_names[i].c_str(),
-							sizeof(amiberry_options.shader) - 1);
+					strncpy(changed_prefs.shader, shader_names[i].c_str(),
+							sizeof(changed_prefs.shader) - 1);
+					changed_prefs.shader[sizeof(changed_prefs.shader) - 1] = '\0';
 				}
 				if (is_selected) ImGui::SetItemDefaultFocus();
 			}
@@ -314,15 +329,16 @@ void render_panel_filter()
 	// RTG Shader Selection
 	BeginGroupBox("RTG Display Shader");
 	{
-		int rtg_idx = find_shader_index(amiberry_options.shader_rtg);
+		int rtg_idx = find_shader_index(changed_prefs.shader_rtg);
 		const float rtg_label_w = ImGui::CalcTextSize("Shader for RTG/Picasso modes").x;
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - rtg_label_w - spacing * 3);
 		if (ImGui::BeginCombo("##RTGShader", shader_items[rtg_idx])) {
 			for (int i = 0; i < static_cast<int>(shader_items.size()); i++) {
 				bool is_selected = (i == rtg_idx);
 				if (ImGui::Selectable(shader_items[i], is_selected)) {
-					strncpy(amiberry_options.shader_rtg, shader_names[i].c_str(),
-							sizeof(amiberry_options.shader_rtg) - 1);
+					strncpy(changed_prefs.shader_rtg, shader_names[i].c_str(),
+							sizeof(changed_prefs.shader_rtg) - 1);
+					changed_prefs.shader_rtg[sizeof(changed_prefs.shader_rtg) - 1] = '\0';
 				}
 				if (is_selected) ImGui::SetItemDefaultFocus();
 			}
@@ -341,35 +357,36 @@ void render_panel_filter()
 	BeginGroupBox("Bezel Overlay");
 	{
 		// Built-in CRT bezel (disabled when custom bezel is active)
-		if (amiberry_options.use_custom_bezel) ImGui::BeginDisabled();
-		if (AmigaCheckbox("Built-in CRT bezel", &amiberry_options.use_bezel)) {
+		if (changed_prefs.use_custom_bezel) ImGui::BeginDisabled();
+		if (AmigaCheckbox("Built-in CRT bezel", &changed_prefs.use_bezel)) {
 			if (g_renderer) g_renderer->update_crtemu_bezel();
 		}
 		ShowHelpMarker("Built-in CRT television bezel frame.\n"
 					   "Only works with built-in CRT shaders (tv, pc, 1084).\n"
 					   "Disabled when a custom bezel is selected.");
-		if (amiberry_options.use_custom_bezel) ImGui::EndDisabled();
+		if (changed_prefs.use_custom_bezel) ImGui::EndDisabled();
 
 		ImGui::Spacing();
 
 		// Custom bezel overlay (disabled when built-in bezel is active)
-		if (amiberry_options.use_bezel) ImGui::BeginDisabled();
+		if (changed_prefs.use_bezel) ImGui::BeginDisabled();
 
 		if (!bezels_initialized) scan_bezels();
 
-		int bezel_idx = find_bezel_index(amiberry_options.custom_bezel);
+		int bezel_idx = find_bezel_index(changed_prefs.custom_bezel);
 		const float bezel_label_w = ImGui::CalcTextSize("Custom bezel overlay").x;
 		ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x - bezel_label_w - spacing * 3);
 		if (ImGui::BeginCombo("##CustomBezel", bezel_items.empty() ? "none" : bezel_items[bezel_idx])) {
 			for (int i = 0; i < static_cast<int>(bezel_items.size()); i++) {
 				bool is_selected = (i == bezel_idx);
 				if (ImGui::Selectable(bezel_items[i], is_selected)) {
-					strncpy(amiberry_options.custom_bezel, bezel_names[i].c_str(),
-							sizeof(amiberry_options.custom_bezel) - 1);
-					amiberry_options.use_custom_bezel = (strcmp(amiberry_options.custom_bezel, "none") != 0);
+					strncpy(changed_prefs.custom_bezel, bezel_names[i].c_str(),
+							sizeof(changed_prefs.custom_bezel) - 1);
+					changed_prefs.custom_bezel[sizeof(changed_prefs.custom_bezel) - 1] = '\0';
+					changed_prefs.use_custom_bezel = (strcmp(changed_prefs.custom_bezel, "none") != 0);
 					// If enabling custom bezel, disable built-in
-					if (amiberry_options.use_custom_bezel) {
-						amiberry_options.use_bezel = false;
+					if (changed_prefs.use_custom_bezel) {
+						changed_prefs.use_bezel = false;
 						if (g_renderer) g_renderer->update_crtemu_bezel();
 					}
 					if (g_renderer) g_renderer->update_custom_bezel();
@@ -385,7 +402,7 @@ void render_panel_filter()
 		ImGui::SameLine();
 		ImGui::Text("Custom bezel overlay");
 
-		if (amiberry_options.use_bezel) ImGui::EndDisabled();
+		if (changed_prefs.use_bezel) ImGui::EndDisabled();
 	}
 	EndGroupBox("Bezel Overlay");
 
@@ -408,8 +425,8 @@ void render_panel_filter()
 	}
 
 	// Save button
-	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save Settings", ImVec2(BUTTON_WIDTH * 1.5f, BUTTON_HEIGHT))) {
-		save_amiberry_settings();
+	if (AmigaButton(ICON_FA_FLOPPY_DISK " Save Defaults", ImVec2(BUTTON_WIDTH * 1.5f, BUTTON_HEIGHT))) {
+		save_filter_defaults();
 	}
 
 	// Render the shader parameters popup if open

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -32,6 +32,7 @@
 #include "statusline.h"
 #include "vkbd/vkbd.h"
 #include "on_screen_joystick.h"
+#include "gui/gui_handling.h"
 #include <cmath>
 #include <SDL3_image/SDL_image.h>
 
@@ -59,6 +60,17 @@ static bool is_kmsdrm_video_driver()
 {
 	const char* driver = SDL_GetCurrentVideoDriver();
 	return driver != nullptr && strcmpi(driver, "KMSDRM") == 0;
+}
+
+static const uae_prefs& get_active_filter_prefs()
+{
+	return gui_running ? changed_prefs : currprefs;
+}
+
+static const char* get_selected_shader_name(const AmigaMonitor* mon)
+{
+	const auto& prefs = get_active_filter_prefs();
+	return mon->screen_is_picasso ? prefs.shader_rtg : prefs.shader;
 }
 
 static void resolve_gl_pixel_format(uint32_t sdl_pixel_format, GLenum& fmt, GLenum& type, int& bpp)
@@ -222,11 +234,7 @@ bool OpenGLRenderer::alloc_texture(int monid, int w, int h)
 	resolve_gl_pixel_format(pixel_format, m_gl_format.fmt, m_gl_format.type, m_gl_format.bpp);
 
 	auto mon = &AMonitors[monid];
-	const char* shader_name;
-	if (mon->screen_is_picasso)
-		shader_name = amiberry_options.shader_rtg;
-	else
-		shader_name = amiberry_options.shader;
+	const char* shader_name = get_selected_shader_name(mon);
 
 	// Skip shader recreation if already loaded with the same name.
 	// This preserves runtime parameter changes made by the user.
@@ -436,10 +444,15 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	}
 	if (desired_aspect <= 0.0f) desired_aspect = 4.0f / 3.0f;
 
+	const auto& filter_prefs = get_active_filter_prefs();
+
 	// Hot-reload shader if user changed it in the GUI while emulation is running
-	const char* wanted_shader = mon->screen_is_picasso ? amiberry_options.shader_rtg : amiberry_options.shader;
+	const char* wanted_shader = mon->screen_is_picasso ? filter_prefs.shader_rtg : filter_prefs.shader;
 	if (m_shader.loaded_name != wanted_shader && surface) {
 		alloc_texture(monid, surface->w, surface->h);
+	}
+	if (m_shader.crtemu != nullptr && m_shader.bezel_enabled != filter_prefs.use_bezel) {
+		update_crtemu_bezel();
 	}
 
 	// Compute bezel display area: letterbox/pillarbox the bezel image within the
@@ -448,7 +461,7 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	int bezelDisplayX = 0, bezelDisplayY = 0;
 	int bezelDisplayW = drawableWidth, bezelDisplayH = drawableHeight;
 
-	if (amiberry_options.use_custom_bezel && m_overlay.bezel_texture != 0 &&
+	if (filter_prefs.use_custom_bezel && m_overlay.bezel_texture != 0 &&
 		m_overlay.bezel_tex_w > 0 && m_overlay.bezel_tex_h > 0) {
 		float bezelAspect = static_cast<float>(m_overlay.bezel_tex_w) / m_overlay.bezel_tex_h;
 		float windowAspect = static_cast<float>(drawableWidth) / drawableHeight;
@@ -472,7 +485,7 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 	int renderAreaX = 0, renderAreaY = 0;
 	int renderAreaW = drawableWidth, renderAreaH = drawableHeight;
 
-	if (amiberry_options.use_custom_bezel && m_overlay.bezel_texture != 0 && m_overlay.bezel_hole_w > 0.0f && m_overlay.bezel_hole_h > 0.0f) {
+	if (filter_prefs.use_custom_bezel && m_overlay.bezel_texture != 0 && m_overlay.bezel_hole_w > 0.0f && m_overlay.bezel_hole_h > 0.0f) {
 		renderAreaX = bezelDisplayX + static_cast<int>(m_overlay.bezel_hole_x * bezelDisplayW);
 		renderAreaY = bezelDisplayY + static_cast<int>(m_overlay.bezel_hole_y * bezelDisplayH);
 		renderAreaW = static_cast<int>(m_overlay.bezel_hole_w * bezelDisplayW);
@@ -908,6 +921,7 @@ void OpenGLRenderer::destroy_shaders()
 		m_shader.crtemu = nullptr;
 		m_shader.external = nullptr;
 		m_shader.preset = nullptr;
+		m_shader.bezel_enabled = false;
 		m_vsync.gl_initialized = false;
 		return;
 	}
@@ -927,6 +941,7 @@ void OpenGLRenderer::destroy_shaders()
 		destroy_shader_preset(m_shader.preset);
 		m_shader.preset = nullptr;
 	}
+	m_shader.bezel_enabled = false;
 	if (m_overlay.osd_program != 0 && glIsProgram(m_overlay.osd_program))
 	{
 		glDeleteProgram(m_overlay.osd_program);
@@ -1020,13 +1035,15 @@ void OpenGLRenderer::update_crtemu_bezel()
 {
 	if (m_shader.crtemu == nullptr)
 		return;
-	if (amiberry_options.use_bezel) {
+	const bool use_bezel = get_active_filter_prefs().use_bezel;
+	if (use_bezel) {
 		static CRTEMU_U32 frame_pixels[CRT_FRAME_WIDTH * CRT_FRAME_HEIGHT];
 		crt_frame(frame_pixels);
 		crtemu_frame(m_shader.crtemu, frame_pixels, CRT_FRAME_WIDTH, CRT_FRAME_HEIGHT);
 	} else {
 		crtemu_frame(m_shader.crtemu, nullptr, 0, 0);
 	}
+	m_shader.bezel_enabled = use_bezel;
 }
 
 BezelHoleInfo OpenGLRenderer::get_bezel_hole_info() const
@@ -1461,23 +1478,23 @@ void OpenGLRenderer::destroy_bezel()
 
 void OpenGLRenderer::render_bezel(int x, int y, int w, int h)
 {
-	// Only re-evaluate bezel state when dirty (avoids per-frame string comparisons)
-	if (m_overlay.bezel_dirty) {
-		if (!amiberry_options.use_custom_bezel ||
-			strcmp(amiberry_options.custom_bezel, "none") == 0) {
-			if (m_overlay.bezel_texture != 0) {
-				destroy_bezel();
-			}
-			m_overlay.bezel_dirty = false;
-			return;
+	const auto& filter_prefs = get_active_filter_prefs();
+	if (!filter_prefs.use_custom_bezel ||
+		strcmp(filter_prefs.custom_bezel, "none") == 0) {
+		if (m_overlay.bezel_texture != 0) {
+			destroy_bezel();
 		}
+		m_overlay.bezel_dirty = false;
+		return;
+	}
 
-		if (m_overlay.loaded_bezel_name != amiberry_options.custom_bezel) {
-			if (m_overlay.bezel_texture != 0) {
-				destroy_bezel();
-			}
-			if (!load_bezel_texture(amiberry_options.custom_bezel)) return;
+	// Re-evaluate when explicitly invalidated or when the active config selects
+	// a different bezel than the one currently loaded.
+	if (m_overlay.bezel_dirty || m_overlay.loaded_bezel_name != filter_prefs.custom_bezel) {
+		if (m_overlay.bezel_texture != 0) {
+			destroy_bezel();
 		}
+		if (!load_bezel_texture(filter_prefs.custom_bezel)) return;
 		m_overlay.bezel_dirty = false;
 	}
 	if (m_overlay.bezel_texture == 0) return;

--- a/src/osdep/opengl_renderer.h
+++ b/src/osdep/opengl_renderer.h
@@ -30,6 +30,7 @@ struct ShaderState {
 	std::string external_name;
 	std::string loaded_name;      // cache key to avoid recreation
 	GLenum texture_filter_mode = GL_LINEAR;
+	bool bezel_enabled = false;
 };
 
 // OpenGL overlay resources: OSD, bezel, software cursor (owned by OpenGLRenderer)

--- a/src/osdep/vulkan_renderer.cpp
+++ b/src/osdep/vulkan_renderer.cpp
@@ -27,6 +27,7 @@
 #include "imgui_impl_vulkan.h"
 #include "picasso96.h"
 #include "target.h"
+#include "gui/gui_handling.h"
 #include "vkbd/vkbd.h"
 #include "on_screen_joystick.h"
 
@@ -37,6 +38,11 @@
 static const std::vector<const char*> device_extensions = {
 	VK_KHR_SWAPCHAIN_EXTENSION_NAME
 };
+
+static const uae_prefs& get_active_filter_prefs()
+{
+	return gui_running ? changed_prefs : currprefs;
+}
 
 #ifndef NDEBUG
 // Validation layers for debug builds
@@ -546,7 +552,8 @@ void VulkanRenderer::destroy_platform_renderer(AmigaMonitor* /*mon*/)
 const char* VulkanRenderer::get_selected_shader_name(int monid) const
 {
 	const auto* mon = &AMonitors[monid];
-	return mon->screen_is_picasso ? amiberry_options.shader_rtg : amiberry_options.shader;
+	const auto& prefs = get_active_filter_prefs();
+	return mon->screen_is_picasso ? prefs.shader_rtg : prefs.shader;
 }
 
 void VulkanRenderer::sync_crt_shader_selection(int monid)
@@ -1049,12 +1056,13 @@ bool VulkanRenderer::render_frame(int monid, int /*mode*/, int /*immediate*/)
 
 	// Bezel overlay (load from file if changed)
 	slot.draw_bezel = false;
-	if (amiberry_options.use_custom_bezel && amiberry_options.custom_bezel[0] != '\0'
-		&& strcmp(amiberry_options.custom_bezel, "none") != 0) {
-		if (m_loaded_bezel_name != amiberry_options.custom_bezel) {
+	const auto& filter_prefs = get_active_filter_prefs();
+	if (filter_prefs.use_custom_bezel && filter_prefs.custom_bezel[0] != '\0'
+		&& strcmp(filter_prefs.custom_bezel, "none") != 0) {
+		if (m_loaded_bezel_name != filter_prefs.custom_bezel) {
 			cleanup_overlay_texture(m_bezel_tex);
 			m_loaded_bezel_name.clear();
-			std::string full_path = get_bezels_path() + amiberry_options.custom_bezel;
+			std::string full_path = get_bezels_path() + filter_prefs.custom_bezel;
 			SDL_Surface* bezel_surf = IMG_Load(full_path.c_str());
 			if (bezel_surf) {
 				SDL_Surface* rgba = SDL_ConvertSurface(bezel_surf, SDL_PIXELFORMAT_ABGR8888);
@@ -1086,7 +1094,7 @@ bool VulkanRenderer::render_frame(int monid, int /*mode*/, int /*immediate*/)
 					m_bezel_tex_h = rgba->h;
 					upload_overlay_texture(m_bezel_tex, rgba);
 					SDL_DestroySurface(rgba);
-					m_loaded_bezel_name = amiberry_options.custom_bezel;
+					m_loaded_bezel_name = filter_prefs.custom_bezel;
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- save filter shader and bezel settings in `.uae` configs instead of only in `amiberry.conf`
- keep `amiberry.conf` as the default source for new configs via the Filter panel `Save Defaults` action
- apply filter changes correctly when switching between configs so stale CRT state does not persist

## Why
Filter settings were global-only, which made it impossible to keep different shader and bezel selections per machine configuration.

## Root Cause
The filter settings lived in `amiberry_options`, so they were not serialized with `.uae` configs. After moving them into `uae_prefs`, config load worked, but runtime config switching still left stale shader/bezel state active because `check_prefs_changed_gfx()` did not propagate the new fields from `changed_prefs` into `currprefs`.

## Impact
- each `.uae` can now carry its own native shader, RTG shader, and bezel selection
- global defaults still exist and remain user-controlled via `amiberry.conf`
- switching from a config with CRT filtering to one without it now clears the filter correctly

## Validation
- `mcp__clion__build_project`
- `cmake --build build -j4 --target amiberry`

Fixes #1954