### PR TITLE
Sync chipset fields when toggling internal IDE/SCSI boards

### DIFF
--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2850,21 +2850,14 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 	if (is_board_enabled(p, ROMTYPE_CD32CART, 0)) {
 		cfgfile_dwrite_bool(f, _T("cd32fmv"), true);
 	}
-	if (is_board_enabled(p, ROMTYPE_MB_IDE, 0) && p->cs_ide == 1) {
-		cfgfile_dwrite_str(f, _T("ide"), _T("a600/a1200"));
-	}
-	if (is_board_enabled(p, ROMTYPE_MB_IDE, 0) && p->cs_ide == 2) {
-		cfgfile_dwrite_str(f, _T("ide"), _T("a4000"));
+	if (p->cs_ide >= 0 && p->cs_ide <= 2) {
+		cfgfile_write_strarr(f, _T("ide"), idemode, p->cs_ide);
 	}
 	if (is_board_enabled(p, ROMTYPE_CDTVSCSI, 0)) {
 		cfgfile_dwrite_bool(f, _T("scsi_cdtv"), true);
 	}
-	if (is_board_enabled(p, ROMTYPE_SCSI_A3000, 0)) {
-		cfgfile_dwrite_bool(f, _T("scsi_a3000"), true);
-	}
-	if (is_board_enabled(p, ROMTYPE_SCSI_A4000T, 0)) {
-		cfgfile_dwrite_bool(f, _T("scsi_a4000t"), true);
-	}
+	cfgfile_write_bool(f, _T("scsi_a3000"), p->cs_mbdmac == 1);
+	cfgfile_write_bool(f, _T("scsi_a4000t"), p->cs_mbdmac == 2);
 
 	cfgfile_dwrite_strarr(f, _T("z3mapping"), z3mapping, p->z3_mapping_mode);
 	cfgfile_dwrite_bool(f, _T("board_custom_order"), p->autoconfig_custom_sort);
@@ -6362,19 +6355,29 @@ static int cfgfile_parse_hardware (struct uae_prefs *p, const TCHAR *option, TCH
 	if (cfgfile_strval(option, value, _T("ide"), &p->cs_ide, idemode, 0)) {
 		if (p->cs_ide)
 			addbcromtype(p, ROMTYPE_MB_IDE, true, nullptr, 0);
+		else
+			addbcromtype(p, ROMTYPE_MB_IDE, false, nullptr, 0);
 		return 1;
 	}
 	if (cfgfile_yesno(option, value, _T("scsi_a3000"), &dummybool)) {
 		if (dummybool) {
+			addbcromtype(p, ROMTYPE_SCSI_A4000T, false, nullptr, 0);
 			addbcromtype(p, ROMTYPE_SCSI_A3000, true, nullptr, 0);
 			p->cs_mbdmac = 1;
+		} else if (p->cs_mbdmac == 1) {
+			addbcromtype(p, ROMTYPE_SCSI_A3000, false, nullptr, 0);
+			p->cs_mbdmac = 0;
 		}
 		return 1;
 	}
 	if (cfgfile_yesno(option, value, _T("scsi_a4000t"), &dummybool)) {
 		if (dummybool) {
+			addbcromtype(p, ROMTYPE_SCSI_A3000, false, nullptr, 0);
 			addbcromtype(p, ROMTYPE_SCSI_A4000T, true, nullptr, 0);
 			p->cs_mbdmac = 2;
+		} else if (p->cs_mbdmac == 2) {
+			addbcromtype(p, ROMTYPE_SCSI_A4000T, false, nullptr, 0);
+			p->cs_mbdmac = 0;
 		}
 		return 1;
 	}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -426,7 +426,14 @@ void fixup_cpu (struct uae_prefs *p)
 
 void fixup_prefs (struct uae_prefs *p, bool userconfig)
 {
-	built_in_chipset_prefs (p);
+	const int saved_cs_ide = p->cs_ide;
+	const int saved_cs_mbdmac = p->cs_mbdmac;
+	built_in_chipset_prefs(p);
+	if (saved_cs_ide != p->cs_ide)
+		p->cs_ide = saved_cs_ide;
+	if (saved_cs_mbdmac != p->cs_mbdmac)
+		p->cs_mbdmac = saved_cs_mbdmac;
+
 	fixup_cpu (p);
 	cfgfile_compatibility_rtg(p);
 #ifdef AMIBERRY

--- a/src/osdep/imgui/expansions.cpp
+++ b/src/osdep/imgui/expansions.cpp
@@ -125,6 +125,41 @@ static int calculate_bit_shift(const expansionboardsettings *ebs, int item_idx)
 	return shift;
 }
 
+static int get_default_internal_ide_mode()
+{
+	if (changed_prefs.cs_ide == IDE_A600A1200 || changed_prefs.cs_ide == IDE_A4000)
+		return changed_prefs.cs_ide;
+	if (changed_prefs.cs_compatible == CP_A4000 || changed_prefs.cs_compatible == CP_A4000T)
+		return IDE_A4000;
+	return IDE_A600A1200;
+}
+
+static bool sync_internal_board_toggle(int romtype, bool enabled)
+{
+	switch (romtype & ROMTYPE_MASK) {
+		case ROMTYPE_MB_IDE:
+			changed_prefs.cs_ide = enabled ? get_default_internal_ide_mode() : 0;
+			break;
+		case ROMTYPE_SCSI_A3000:
+			if (enabled)
+				changed_prefs.cs_mbdmac = 1;
+			else if (changed_prefs.cs_mbdmac == 1)
+				changed_prefs.cs_mbdmac = 0;
+			break;
+		case ROMTYPE_SCSI_A4000T:
+			if (enabled)
+				changed_prefs.cs_mbdmac = 2;
+			else if (changed_prefs.cs_mbdmac == 2)
+				changed_prefs.cs_mbdmac = 0;
+			break;
+		default:
+			return false;
+	}
+
+	cfgfile_compatibility_romtype(&changed_prefs);
+	return true;
+}
+
 static void RefreshExpansionList() {
     displayed_rom_indices.clear();
     int first_match = -1;
@@ -368,7 +403,10 @@ void render_panel_expansions() {
 
     // Enable Checkbox
     if (ert && AmigaCheckbox("Enable Board", &enabled)) {
-        if (enabled) {
+        if (sync_internal_board_toggle(ert->romtype, enabled)) {
+            brc = get_device_rom(&changed_prefs, ert->romtype, scsiromselectednum, &index);
+            enabled = (brc != nullptr);
+        } else if (enabled) {
             if (!brc) {
                 brc = get_device_rom_new(&changed_prefs, ert->romtype, scsiromselectednum, &index);
             }


### PR DESCRIPTION
## Summary
- Fixes #1956: internal IDE/SCSI boards could not be disabled/enabled from the Expansions panel because only the board list was updated, not the backing chipset fields (`cs_ide`, `cs_mbdmac`). `built_in_chipset_prefs()` silently overwrote user changes on every save/load cycle.
- Always persist `ide=`, `scsi_a3000=`, `scsi_a4000t=` to config files (including disabled state)
- Handle disable case in config parser with mutual exclusion between A3000/A4000T SCSI
- Preserve user-set `cs_ide`/`cs_mbdmac` across `built_in_chipset_prefs()` in `fixup_prefs()`
- Expansions GUI now updates chipset fields when toggling internal boards

## Test plan
- [ ] Load the config from #1956 (A3000-030-MMU with A4000 IDE accidentally enabled)
- [ ] Disable A4000 IDE in Expansions, save config, reload — verify it stays disabled
- [ ] Enable A3000 SCSI in Expansions, save config, reload — verify it stays enabled
- [ ] Verify A3000 SCSI and A4000T SCSI are mutually exclusive (enabling one disables the other)
- [ ] Test with A1200 config: toggle IDE off/on, save/load round-trip
- [ ] Test with A4000T config: verify A4000T SCSI persists correctly