### PR TITLE
Fix GUI window filling entire screen after full-window emulation on macOS

### DIFF
--- a/src/osdep/gui/main_window.cpp
+++ b/src/osdep/gui/main_window.cpp
@@ -1362,9 +1362,33 @@ void amiberry_gui_init()
 			SDL_SyncWindow(mon->gui_window);
 		}
 		if (mon->gui_window) {
-			// Sync rect to actual window size (SDL may adjust)
+			// Keep the intended GUI size — SDL may create the window larger
+			// than requested (e.g. on macOS when returning from a full-window
+			// Space).  We enforce our intended size below instead of blindly
+			// accepting whatever SDL reports.
+			const int intended_w = gui_window_rect.w;
+			const int intended_h = gui_window_rect.h;
 			int ww, wh;
 			SDL_GetWindowSize(mon->gui_window, &ww, &wh);
+
+			SDL_WindowFlags wflags = SDL_GetWindowFlags(mon->gui_window);
+
+			// If the window ended up larger than intended (or maximized/
+			// fullscreen), force it back to the intended dimensions.
+			// This happens on macOS when returning from a full-window Space.
+			if (ww != intended_w || wh != intended_h
+				|| (wflags & (SDL_WINDOW_MAXIMIZED | SDL_WINDOW_FULLSCREEN))) {
+				write_log("GUI window: SDL reports %dx%d (flags=0x%x) but intended %dx%d — correcting\n",
+					ww, wh, (unsigned)wflags, intended_w, intended_h);
+				if (wflags & SDL_WINDOW_MAXIMIZED)
+					SDL_RestoreWindow(mon->gui_window);
+				if (wflags & SDL_WINDOW_FULLSCREEN)
+					SDL_SetWindowFullscreen(mon->gui_window, false);
+				SDL_SetWindowSize(mon->gui_window, intended_w, intended_h);
+				SDL_SyncWindow(mon->gui_window);
+				ww = intended_w;
+				wh = intended_h;
+			}
 			gui_window_rect.w = ww;
 			gui_window_rect.h = wh;
 
@@ -1703,10 +1727,17 @@ void amiberry_gui_halt()
 		// Always save position and size together so the ini stays consistent.
 		// Avoids stale position-only state causing top-left placement on first
 		// launch after upgrading from a version that didn't persist size.
+		// Skip saving dimensions when the window is maximized — the maximized
+		// size is transient (screen-dependent) and would overwrite the user's
+		// preferred normal-window size, causing it to appear maximized on every
+		// subsequent launch.
+		const bool is_maximized = (SDL_GetWindowFlags(mon->gui_window) & SDL_WINDOW_MAXIMIZED) != 0;
 		regsetint(nullptr, _T("GUIPosX"), gui_window_rect.x);
 		regsetint(nullptr, _T("GUIPosY"), gui_window_rect.y);
-		regsetint(nullptr, _T("GUISizeW"), gui_window_rect.w);
-		regsetint(nullptr, _T("GUISizeH"), gui_window_rect.h);
+		if (!is_maximized) {
+			regsetint(nullptr, _T("GUISizeW"), gui_window_rect.w);
+			regsetint(nullptr, _T("GUISizeH"), gui_window_rect.h);
+		}
 #if defined(__ANDROID__)
 		// Don't destroy the window on Android, as we reuse it
 #elif defined(_WIN32)
@@ -1907,9 +1938,12 @@ void run_gui()
 			}
 			else if (gui_event.type == SDL_EVENT_WINDOW_RESIZED
 				&& gui_event.window.windowID == SDL_GetWindowID(mon->gui_window)) {
-				gui_window_rect.w = gui_event.window.data1;
-				gui_window_rect.h = gui_event.window.data2;
-
+				// Don't track size changes caused by the window being maximized —
+				// we only want to persist the user's normal (restored) window size.
+				if (!(SDL_GetWindowFlags(mon->gui_window) & SDL_WINDOW_MAXIMIZED)) {
+					gui_window_rect.w = gui_event.window.data1;
+					gui_window_rect.h = gui_event.window.data2;
+				}
 			}
 			else if (gui_event.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED
 				&& gui_event.window.windowID == SDL_GetWindowID(mon->gui_window)) {


### PR DESCRIPTION
## Summary
- Fixes #1930
- On macOS, opening the GUI after running emulation in full-window mode caused the GUI window to fill the entire screen instead of using the stored dimensions from the ini file
- The oversized window dimensions then got saved to the ini, making the problem persistent

## Changes
- **Window creation**: preserve the intended size before querying SDL; if SDL reports a larger window (or sets maximized/fullscreen flags), force it back to the intended dimensions
- **Save logic**: skip persisting `GUISizeW`/`GUISizeH` when the window is maximized, so the user's preferred size is never overwritten
- **Event loop**: ignore `SDL_EVENT_WINDOW_RESIZED` events caused by maximization to keep `gui_window_rect` tracking the normal (restored) size

## Test plan
- [ ] Launch a config using Full-Window mode on macOS
- [ ] Press F12 to open the GUI — window should appear at its stored size, not filling the screen
- [ ] Close and reopen the GUI — size should remain consistent
- [ ] Manually resize the GUI window, close and reopen — new size should be remembered
- [ ] Verify no regression on Linux (separate GUI window path) and Windows (shared window path)