### PR TITLE
fix(rtg): zero-copy refresh holes + OpenGL render-path perf

### DIFF
--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -313,14 +313,16 @@ static bool amiberry_renderframe(const int monid, int mode, int immediate)
 	{
 		update_leds(monid);
 	}
-#ifdef WITH_THREADED_CPU
+	// Consume the zero-copy refresh request. The flag is set by picasso96
+	// state changes (SetDisplay, SetPanning) and forces the host surface
+	// binding to follow the current Amiga VRAM address. This is orthogonal
+	// to WITH_THREADED_CPU so must not be wrapped by that define.
 	if (ad->picasso_zero_copy_update_needed) {
 		const_cast<amigadisplay*>(ad)->picasso_zero_copy_update_needed = false;
 		if (currprefs.rtg_zerocopy) {
 			target_graphics_buffer_update(monid, true);
 		}
 	}
-#endif
 	IRenderer* renderer = get_renderer(monid);
 	return renderer ? renderer->render_frame(monid, mode, immediate) : false;
 }

--- a/src/osdep/opengl_renderer.cpp
+++ b/src/osdep/opengl_renderer.cpp
@@ -717,55 +717,58 @@ void OpenGLRenderer::present_frame(int monid, int mode)
 
 // --- External shader rendering ---
 
+// Fullscreen quad used by render_external_shader. Uploaded once per VBO
+// creation with GL_STATIC_DRAW; attribute layout captured in the VAO so the
+// per-frame path only needs to bind the VAO and draw.
+//   Layout: VertexCoord (vec4: x,y,z,w), TexCoord (s,t, _,_)  — stride 8 floats
+//   Constant vertex color is supplied via glVertexAttrib4f at VAO setup time
+//   (captured in the VAO's generic attribute state for the default value).
+static const float k_external_shader_quad[] = {
+	// VertexCoord                TexCoord
+	-1.0f, -1.0f, 0.0f, 1.0f,    0.0f, 1.0f, 0.0f, 0.0f,  // Bottom-left
+	 1.0f, -1.0f, 0.0f, 1.0f,    1.0f, 1.0f, 0.0f, 0.0f,  // Bottom-right
+	 1.0f,  1.0f, 0.0f, 1.0f,    1.0f, 0.0f, 0.0f, 0.0f,  // Top-right
+	-1.0f,  1.0f, 0.0f, 1.0f,    0.0f, 0.0f, 0.0f, 0.0f   // Top-left
+};
+
 void OpenGLRenderer::render_external_shader(ExternalShader* shader, const int monid,
 	const uae_u8* pixels, int width, int height, int pitch,
 	int viewport_x, int viewport_y, int viewport_width, int viewport_height)
 {
-	if (!shader || !shader->is_valid()) {
-		write_log("render_external_shader: shader is null or invalid\n");
-		return;
-	}
-
-	if (!pixels) {
-		write_log("render_external_shader: pixels is NULL!\n");
-		return;
-	}
-
-	// Clear any existing GL errors
-	(void)glGetError();
-
-	if (!shader->is_valid() || !glIsProgram(shader->get_program())) {
-		write_log("render_external_shader: shader program is invalid or lost. Attempting to reload...\n");
+	if (!shader || !shader->is_valid() || !pixels) {
 		return;
 	}
 
 	GLuint texture = shader->get_input_texture();
 	GLuint vbo = shader->get_input_vbo();
 	GLuint vao = shader->get_input_vao();
+
+	// Per-shader frame counter — only ticks while this shader actually renders.
 	static int frame_count = 0;
 
-	// Verify resources are still valid for this context
-	if (texture != 0 && !glIsTexture(texture)) {
-		write_log("render_external_shader: texture lost, resetting\n");
-		texture = 0;
-		shader->set_input_texture(0);
-	}
-	if (vbo != 0 && !glIsBuffer(vbo)) {
-		write_log("render_external_shader: VBO lost, resetting\n");
-		vbo = 0;
-		shader->set_input_vbo(0);
-	}
-	if (vao != 0 && !glIsVertexArray(vao)) {
-		write_log("render_external_shader: VAO lost, resetting\n");
-		vao = 0;
-		shader->set_input_vao(0);
+	// Per-shader texture upload cache. last_w/last_h/last_texture track whether
+	// we need a full glTexImage2D allocation or just a glTexSubImage2D upload.
+	// Reset when the shader program changes (i.e. user picked a different shader).
+	static GLuint last_shader_program = 0;
+	static int last_w = 0, last_h = 0;
+	static GLuint last_texture = 0;
+	const GLuint current_program = shader->get_program();
+	if (current_program != last_shader_program) {
+		last_shader_program = current_program;
+		last_w = 0;
+		last_h = 0;
+		last_texture = 0;
 	}
 
-	// Create texture if needed
+	// --- One-time resource setup -------------------------------------------
+	// Resources are created the first time this shader renders and then reused.
+	// We don't validate them with glIs* every frame — those calls cost a
+	// driver round-trip and are unnecessary when destruction goes through
+	// ExternalShader::cleanup().
 	if (texture == 0) {
 		glGenTextures(1, &texture);
 		if (texture == 0) {
-			write_log("ERROR: Failed to create texture!\n");
+			write_log("render_external_shader: glGenTextures failed\n");
 			return;
 		}
 		shader->set_input_texture(texture);
@@ -777,135 +780,99 @@ void OpenGLRenderer::render_external_shader(ExternalShader* shader, const int mo
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	}
 
-	// Create VAO if needed
-	if (vao == 0) {
-		glGenVertexArrays(1, &vao);
+	if (vao == 0 || vbo == 0) {
 		if (vao == 0) {
-			write_log("ERROR: Failed to create VAO!\n");
-			return;
+			glGenVertexArrays(1, &vao);
+			if (vao == 0) {
+				write_log("render_external_shader: glGenVertexArrays failed\n");
+				return;
+			}
+			shader->set_input_vao(vao);
 		}
-		shader->set_input_vao(vao);
-	}
-	glBindVertexArray(vao);
-
-	// Create VBO if needed
-	if (vbo == 0) {
-		glGenBuffers(1, &vbo);
 		if (vbo == 0) {
-			write_log("ERROR: Failed to create VBO!\n");
-			return;
+			glGenBuffers(1, &vbo);
+			if (vbo == 0) {
+				write_log("render_external_shader: glGenBuffers failed\n");
+				return;
+			}
+			shader->set_input_vbo(vbo);
 		}
-		shader->set_input_vbo(vbo);
+
+		// Configure the VAO once: bind buffer, upload static quad, wire up
+		// attributes. GL captures the attribute→buffer binding inside the VAO
+		// so per-frame dispatch only needs glBindVertexArray + glDrawArrays.
+		glBindVertexArray(vao);
 		glBindBuffer(GL_ARRAY_BUFFER, vbo);
+		glBufferData(GL_ARRAY_BUFFER, sizeof(k_external_shader_quad),
+			k_external_shader_quad, GL_STATIC_DRAW);
+
+		const GLsizei stride = 8 * sizeof(float);
+		// Attribute 0: VertexCoord (vec4)
+		glEnableVertexAttribArray(0);
+		glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, stride, nullptr);
+		// Attribute 1: Color (vec4) — constant white. Set the generic
+		// attribute once; it persists with the VAO's state.
+		glDisableVertexAttribArray(1);
+		glVertexAttrib4f(1, 1.0f, 1.0f, 1.0f, 1.0f);
+		// Attribute 2: TexCoord (vec2 of 4 floats per vertex)
+		glEnableVertexAttribArray(2);
+		glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride,
+			reinterpret_cast<void*>(4 * sizeof(float)));
+
+		glBindVertexArray(0);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 
-	// Ensure we're rendering to the default framebuffer (screen)
+	// --- Per-frame fast path -----------------------------------------------
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-	// Set viewport explicitly
 	glViewport(viewport_x, viewport_y, viewport_width, viewport_height);
-
-	// Set up GL state for 2D rendering
-	glDisable(GL_DEPTH_TEST);
-	glDisable(GL_CULL_FACE);
-	glDisable(GL_BLEND);
-	glDisable(GL_SCISSOR_TEST);
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, texture);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, pitch / m_gl_format.bpp);
 
-	// Track texture changes per-shader to handle shader switches properly
-	GLuint current_program = shader->get_program();
-	static int last_w = 0, last_h = 0;
-	static GLuint last_texture = 0;
-	static GLuint last_shader_program = 0;
-
-	// Reset cache if shader changed
-	if (current_program != last_shader_program) {
-		last_w = 0;
-		last_h = 0;
-		last_texture = 0;
-		last_shader_program = current_program;
-	}
-
 	if (width != last_w || height != last_h || texture != last_texture) {
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, m_gl_format.fmt, m_gl_format.type, pixels);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0,
+			m_gl_format.fmt, m_gl_format.type, pixels);
 		last_w = width;
 		last_h = height;
 		last_texture = texture;
 	} else {
-		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, m_gl_format.fmt, m_gl_format.type, pixels);
+		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height,
+			m_gl_format.fmt, m_gl_format.type, pixels);
 	}
-
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
-	// Use the shader
 	shader->use();
 
-	// Set uniforms
+	// Standard shader uniforms. Drivers cache uniform state per-program so
+	// setting these every frame is cheap; frame_count must update per call.
 	shader->set_texture_size(static_cast<float>(width), static_cast<float>(height));
 	shader->set_input_size(static_cast<float>(width), static_cast<float>(height));
 
-	int safe_output_w = (viewport_width >= width) ? viewport_width : width;
-	int safe_output_h = (viewport_height >= height) ? viewport_height : height;
-	shader->set_output_size(static_cast<float>(safe_output_w), static_cast<float>(safe_output_h));
+	const int safe_output_w = (viewport_width >= width) ? viewport_width : width;
+	const int safe_output_h = (viewport_height >= height) ? viewport_height : height;
+	shader->set_output_size(static_cast<float>(safe_output_w),
+		static_cast<float>(safe_output_h));
 	shader->set_frame_count(frame_count++);
 
-	// Set MVP matrix (orthographic projection for fullscreen quad)
-	float mvp[16] = {
+	// Identity MVP — no projection is needed for the fullscreen clip-space quad.
+	static const float mvp_identity[16] = {
 		1.0f, 0.0f, 0.0f, 0.0f,
 		0.0f, 1.0f, 0.0f, 0.0f,
 		0.0f, 0.0f, 1.0f, 0.0f,
 		0.0f, 0.0f, 0.0f, 1.0f
 	};
-	shader->set_mvp_matrix(mvp);
+	shader->set_mvp_matrix(mvp_identity);
 
-	// Apply parameter uniforms
 	shader->apply_parameter_uniforms();
-
-	// Bind texture
 	shader->bind_texture(texture, 0);
 
-	// Set up vertex data for fullscreen quad
-	glBindBuffer(GL_ARRAY_BUFFER, vbo);
-
-	float vertices[] = {
-		// VertexCoord (x,y,z,w), TexCoord (s,t,0,0)
-		-1.0f, -1.0f, 0.0f, 1.0f,   0.0f, 1.0f, 0.0f, 0.0f,  // Bottom-left
-		 1.0f, -1.0f, 0.0f, 1.0f,   1.0f, 1.0f, 0.0f, 0.0f,  // Bottom-right
-		 1.0f,  1.0f, 0.0f, 1.0f,   1.0f, 0.0f, 0.0f, 0.0f,  // Top-right
-		-1.0f,  1.0f, 0.0f, 1.0f,   0.0f, 0.0f, 0.0f, 0.0f   // Top-left
-	};
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_DYNAMIC_DRAW);
-
-	glDisableVertexAttribArray(0);
-	glDisableVertexAttribArray(1);
-	glDisableVertexAttribArray(2);
-
-	const GLsizei stride = 8 * sizeof(float);
-
-	// Attribute 0: VertexCoord (vec4: x, y, z, w)
-	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, stride, nullptr);
-
-	// Attribute 1: Color (vec4) - Set to white by default
-	glVertexAttrib4f(1, 1.0f, 1.0f, 1.0f, 1.0f);
-
-	// Attribute 2: TexCoord (vec2: s, t)
-	glEnableVertexAttribArray(2);
-	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, (void*)(4 * sizeof(float)));
-
-	// Draw fullscreen quad
+	glBindVertexArray(vao);
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-
-	// Cleanup
-	glDisableVertexAttribArray(0);
-	glDisableVertexAttribArray(2);
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
-	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindVertexArray(0);
+	glBindTexture(GL_TEXTURE_2D, 0);
 }
 
 // --- Shader management ---

--- a/src/osdep/picasso96.cpp
+++ b/src/osdep/picasso96.cpp
@@ -1449,9 +1449,12 @@ static void picasso_handle_vsync2(struct AmigaMonitor *mon)
 
 	// SetPanning can change the visible VRAM base (XYOffset) without changing
 	// mode dimensions/format. Ensure host buffer binding is refreshed so
-	// zero-copy paths follow the new source address.
+	// zero-copy paths follow the new source address. Use force=true so the
+	// early-return shortcut in target_graphics_buffer_update cannot skip the
+	// rebind (and so full_render_needed is always set) when the new source
+	// address happens to coincide with the previously bound pointer.
 	if (panning_state_changed) {
-		target_graphics_buffer_update(monid, false);
+		target_graphics_buffer_update(monid, true);
 	}
 
 	if (ad->picasso_on) {
@@ -3777,6 +3780,17 @@ static uae_u32 REGPARAM2 picasso_SetPanning (TrapContext *ctx)
 		bme_width, bme_height,
 		start_of_screen, state->BytesPerRow, state->BytesPerPixel, state->RGBFormat));
 
+#ifdef AMIBERRY
+	// SetPanning can change the visible VRAM base without SetDisplay being
+	// called (subsequent Picasso screens, e.g. switching between Workbench
+	// and a promoted application screen). Signal the host renderer to
+	// refresh its zero-copy binding at the next frame in addition to the
+	// SETPANNING state-change processing.
+	if (currprefs.rtg_zerocopy) {
+		adisplays[monid].picasso_zero_copy_update_needed = true;
+	}
+#endif
+
 	atomic_or(&vidinfo->picasso_state_change, PICASSO_STATE_SETPANNING);
 
 	unlockrtg();
@@ -6042,8 +6056,58 @@ static int render_thread(void *v)
 	return 0;
 }
 
+// RTG memory banks: use MEMORY_FUNCTIONS for the read/check/xlate halves but
+// provide custom put functions that also call mark_dirty(). Without this,
+// direct CPU writes to VRAM (software renderers, games bypassing the P96 API,
+// Lightwave's 2D viewports, etc.) are invisible to picasso_getwritewatch and
+// renderers that gate uploads on the dirty-rect list (SDL, Vulkan).
+// On WinUAE-native Windows builds the write-watch is provided by the OS
+// (GetWriteWatch) and mark_dirty is not defined, so fall back to the stock
+// MEMORY_FUNCTIONS in that case.
+#if !defined(_WIN32) || defined(AMIBERRY)
+#define GFXMEM_PUT_FUNCTIONS(name, index) \
+static void REGPARAM3 name ## _lput (uaecptr, uae_u32) REGPARAM; \
+static void REGPARAM2 name ## _lput (uaecptr addr, uae_u32 l) \
+{ \
+	uae_u8 *m; \
+	addr -= name ## _bank.startaccessmask; \
+	addr &= name ## _bank.mask; \
+	m = name ## _bank.baseaddr + addr; \
+	do_put_mem_long ((uae_u32 *)m, l); \
+	mark_dirty((index), m, 4); \
+} \
+static void REGPARAM3 name ## _wput (uaecptr, uae_u32) REGPARAM; \
+static void REGPARAM2 name ## _wput (uaecptr addr, uae_u32 w) \
+{ \
+	uae_u8 *m; \
+	addr -= name ## _bank.startaccessmask; \
+	addr &= name ## _bank.mask; \
+	m = name ## _bank.baseaddr + addr; \
+	do_put_mem_word ((uae_u16 *)m, w); \
+	mark_dirty((index), m, 2); \
+} \
+static void REGPARAM3 name ## _bput (uaecptr, uae_u32) REGPARAM; \
+static void REGPARAM2 name ## _bput (uaecptr addr, uae_u32 b) \
+{ \
+	addr -= name ## _bank.startaccessmask; \
+	addr &= name ## _bank.mask; \
+	name ## _bank.baseaddr[addr] = b; \
+	mark_dirty((index), name ## _bank.baseaddr + addr, 1); \
+}
+
+#define GFXMEM_MEMORY_FUNCTIONS(name, index) \
+MEMORY_LGET(name); \
+MEMORY_WGET(name); \
+MEMORY_BGET(name); \
+GFXMEM_PUT_FUNCTIONS(name, index) \
+MEMORY_CHECK(name); \
+MEMORY_XLATE(name);
+#else
+#define GFXMEM_MEMORY_FUNCTIONS(name, index) MEMORY_FUNCTIONS(name)
+#endif
+
 extern addrbank gfxmem_bank;
-MEMORY_FUNCTIONS(gfxmem);
+GFXMEM_MEMORY_FUNCTIONS(gfxmem, 0)
 addrbank gfxmem_bank = {
 	gfxmem_lget, gfxmem_wget, gfxmem_bget,
 	gfxmem_lput, gfxmem_wput, gfxmem_bput,
@@ -6052,7 +6116,7 @@ addrbank gfxmem_bank = {
 	ABFLAG_RAM | ABFLAG_RTG | ABFLAG_DIRECTACCESS | ABFLAG_THREADSAFE, 0, 0
 };
 extern addrbank gfxmem2_bank;
-MEMORY_FUNCTIONS(gfxmem2);
+GFXMEM_MEMORY_FUNCTIONS(gfxmem2, 1)
 addrbank gfxmem2_bank = {
 	gfxmem2_lget, gfxmem2_wget, gfxmem2_bget,
 	gfxmem2_lput, gfxmem2_wput, gfxmem2_bput,
@@ -6061,7 +6125,7 @@ addrbank gfxmem2_bank = {
 	ABFLAG_RAM | ABFLAG_RTG | ABFLAG_DIRECTACCESS | ABFLAG_THREADSAFE, 0, 0
 };
 extern addrbank gfxmem3_bank;
-MEMORY_FUNCTIONS(gfxmem3);
+GFXMEM_MEMORY_FUNCTIONS(gfxmem3, 2)
 addrbank gfxmem3_bank = {
 	gfxmem3_lget, gfxmem3_wget, gfxmem3_bget,
 	gfxmem3_lput, gfxmem3_wput, gfxmem3_bput,
@@ -6070,7 +6134,7 @@ addrbank gfxmem3_bank = {
 	ABFLAG_RAM | ABFLAG_RTG | ABFLAG_DIRECTACCESS | ABFLAG_THREADSAFE, 0, 0
 };
 extern addrbank gfxmem4_bank;
-MEMORY_FUNCTIONS(gfxmem4);
+GFXMEM_MEMORY_FUNCTIONS(gfxmem4, 3)
 addrbank gfxmem4_bank = {
 	gfxmem4_lget, gfxmem4_wget, gfxmem4_bget,
 	gfxmem4_lput, gfxmem4_wput, gfxmem4_bput,

--- a/src/osdep/shader_preset.cpp
+++ b/src/osdep/shader_preset.cpp
@@ -738,10 +738,10 @@ bool ShaderPreset::run_flip_pass(int width, int height)
 	if (!ensure_flip_resources()) return false;
 
 	// Ensure destination (original_texture_) matches the current frame size.
-	// We rely on the caller having already uploaded source_texture_ at these
-	// dimensions.
-	static int flip_dest_w = 0;
-	static int flip_dest_h = 0;
+	// flip_dest_w_/flip_dest_h_ are member fields — not function-local
+	// statics — so that multiple ShaderPreset instances keep independent
+	// caches, and recreating original_texture_ on the same instance still
+	// triggers a fresh glTexImage2D + FBO attach.
 	if (original_texture_ == 0) {
 		glGenTextures(1, &original_texture_);
 		glBindTexture(GL_TEXTURE_2D, original_texture_);
@@ -749,15 +749,15 @@ bool ShaderPreset::run_flip_pass(int width, int height)
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-		flip_dest_w = 0;
-		flip_dest_h = 0;
+		flip_dest_w_ = 0;
+		flip_dest_h_ = 0;
 	}
-	if (width != flip_dest_w || height != flip_dest_h) {
+	if (width != flip_dest_w_ || height != flip_dest_h_) {
 		glBindTexture(GL_TEXTURE_2D, original_texture_);
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0,
 			GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-		flip_dest_w = width;
-		flip_dest_h = height;
+		flip_dest_w_ = width;
+		flip_dest_h_ = height;
 
 		glBindFramebuffer(GL_FRAMEBUFFER, flip_fbo_);
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,

--- a/src/osdep/shader_preset.cpp
+++ b/src/osdep/shader_preset.cpp
@@ -51,11 +51,28 @@ void ShaderPreset::cleanup()
 	}
 	lut_textures_.clear();
 
+	if (source_texture_ != 0) {
+		if (glIsTexture(source_texture_))
+			glDeleteTextures(1, &source_texture_);
+		source_texture_ = 0;
+	}
 	if (original_texture_ != 0) {
 		if (glIsTexture(original_texture_))
 			glDeleteTextures(1, &original_texture_);
 		original_texture_ = 0;
 	}
+	if (flip_fbo_ != 0) {
+		// Matches pass.fbo cleanup above — glIsFramebuffer is not loaded
+		// through gl_platform's function pointer table, so skip the check.
+		glDeleteFramebuffers(1, &flip_fbo_);
+		flip_fbo_ = 0;
+	}
+	if (flip_program_ != 0) {
+		if (glIsProgram(flip_program_))
+			glDeleteProgram(flip_program_);
+		flip_program_ = 0;
+	}
+	flip_u_source_ = -1;
 	if (shared_vbo_ != 0) {
 		if (glIsBuffer(shared_vbo_))
 			glDeleteBuffers(1, &shared_vbo_);
@@ -593,9 +610,10 @@ void ShaderPreset::setup_shared_vertex_data()
 	glBindBuffer(GL_ARRAY_BUFFER, shared_vbo_);
 
 	// RetroArch convention: TexCoord (0,0) at bottom-left, (1,1) at top-right.
-	// The original texture is uploaded with rows flipped (see render()) so the
-	// texture matches GL convention and these coordinates produce correct output.
-	float vertices[] = {
+	// The SDL surface arrives top-down; an internal Y-flip pre-pass (see
+	// run_flip_pass) writes the properly-oriented image into original_texture_
+	// so these texcoords produce the correct orientation for user passes.
+	static const float vertices[] = {
 		// VertexCoord (x,y,z,w), TexCoord (s,t,0,0)
 		-1.0f, -1.0f, 0.0f, 1.0f,   0.0f, 0.0f, 0.0f, 0.0f,  // Bottom-left
 		 1.0f, -1.0f, 0.0f, 1.0f,   1.0f, 0.0f, 0.0f, 0.0f,  // Bottom-right
@@ -604,8 +622,172 @@ void ShaderPreset::setup_shared_vertex_data()
 	};
 	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	// Bake attribute configuration into the VAO so the per-pass loop only
+	// needs to bind the VAO to render. Matches the attribute locations
+	// assigned by ExternalShader (VertexCoord=0, Color=1, TexCoord=2).
+	const GLsizei stride = 8 * sizeof(float);
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, stride, nullptr);
+	// Attribute 1 is a constant white — supplied via glVertexAttrib4f.
+	glDisableVertexAttribArray(1);
+	glVertexAttrib4f(1, 1.0f, 1.0f, 1.0f, 1.0f);
+	glEnableVertexAttribArray(2);
+	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride,
+		reinterpret_cast<void*>(4 * sizeof(float)));
+
 	glBindVertexArray(0);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+}
+
+// ---- Y-flip pre-pass ----
+
+// Minimal passthrough shader that samples the top-down source texture with
+// Y-inverted coordinates, producing a GL-convention image in the destination
+// FBO. Uses legacy-style `attribute`/`varying`/`gl_FragColor`/`texture2D` so
+// the same source compiles on both GLSL 120 (no preamble) and the modern
+// core/GLES preambles returned by get_gl_shader_preambles() (which `#define`
+// these to their core equivalents).
+namespace {
+
+const char* k_flip_vs =
+	"attribute vec4 VertexCoord;\n"
+	"attribute vec2 TexCoord;\n"
+	"varying vec2 vTex;\n"
+	"void main()\n"
+	"{\n"
+	"    gl_Position = VertexCoord;\n"
+	"    vTex = TexCoord;\n"
+	"}\n";
+
+const char* k_flip_fs =
+	"varying vec2 vTex;\n"
+	"uniform sampler2D Source;\n"
+	"void main()\n"
+	"{\n"
+	"    gl_FragColor = texture2D(Source, vec2(vTex.x, 1.0 - vTex.y));\n"
+	"}\n";
+
+} // namespace
+
+bool ShaderPreset::ensure_flip_resources()
+{
+	if (flip_program_ != 0) return true;
+
+	const auto& preambles = get_gl_shader_preambles();
+
+	GLuint vs = glCreateShader(GL_VERTEX_SHADER);
+	const char* vs_sources[] = { preambles.vs, k_flip_vs };
+	glShaderSource(vs, 2, vs_sources, nullptr);
+	glCompileShader(vs);
+	GLint compiled = 0;
+	glGetShaderiv(vs, GL_COMPILE_STATUS, &compiled);
+	if (!compiled) {
+		char infoLog[512];
+		glGetShaderInfoLog(vs, sizeof(infoLog), nullptr, infoLog);
+		write_log("ShaderPreset flip VS compile error: %s\n", infoLog);
+		glDeleteShader(vs);
+		return false;
+	}
+
+	GLuint fs = glCreateShader(GL_FRAGMENT_SHADER);
+	const char* fs_sources[] = { preambles.fs, k_flip_fs };
+	glShaderSource(fs, 2, fs_sources, nullptr);
+	glCompileShader(fs);
+	glGetShaderiv(fs, GL_COMPILE_STATUS, &compiled);
+	if (!compiled) {
+		char infoLog[512];
+		glGetShaderInfoLog(fs, sizeof(infoLog), nullptr, infoLog);
+		write_log("ShaderPreset flip FS compile error: %s\n", infoLog);
+		glDeleteShader(vs);
+		glDeleteShader(fs);
+		return false;
+	}
+
+	flip_program_ = glCreateProgram();
+	glAttachShader(flip_program_, vs);
+	glAttachShader(flip_program_, fs);
+	// Match the shared VAO's attribute locations.
+	glBindAttribLocation(flip_program_, 0, "VertexCoord");
+	glBindAttribLocation(flip_program_, 2, "TexCoord");
+	glLinkProgram(flip_program_);
+
+	GLint linked = 0;
+	glGetProgramiv(flip_program_, GL_LINK_STATUS, &linked);
+	glDeleteShader(vs);
+	glDeleteShader(fs);
+	if (!linked) {
+		char infoLog[512];
+		glGetProgramInfoLog(flip_program_, sizeof(infoLog), nullptr, infoLog);
+		write_log("ShaderPreset flip program link error: %s\n", infoLog);
+		glDeleteProgram(flip_program_);
+		flip_program_ = 0;
+		return false;
+	}
+
+	flip_u_source_ = glGetUniformLocation(flip_program_, "Source");
+
+	if (flip_fbo_ == 0) {
+		glGenFramebuffers(1, &flip_fbo_);
+	}
+
+	return flip_program_ != 0 && flip_fbo_ != 0;
+}
+
+bool ShaderPreset::run_flip_pass(int width, int height)
+{
+	if (!ensure_flip_resources()) return false;
+
+	// Ensure destination (original_texture_) matches the current frame size.
+	// We rely on the caller having already uploaded source_texture_ at these
+	// dimensions.
+	static int flip_dest_w = 0;
+	static int flip_dest_h = 0;
+	if (original_texture_ == 0) {
+		glGenTextures(1, &original_texture_);
+		glBindTexture(GL_TEXTURE_2D, original_texture_);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		flip_dest_w = 0;
+		flip_dest_h = 0;
+	}
+	if (width != flip_dest_w || height != flip_dest_h) {
+		glBindTexture(GL_TEXTURE_2D, original_texture_);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0,
+			GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+		flip_dest_w = width;
+		flip_dest_h = height;
+
+		glBindFramebuffer(GL_FRAMEBUFFER, flip_fbo_);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+			GL_TEXTURE_2D, original_texture_, 0);
+		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+			write_log("ShaderPreset flip FBO incomplete at %dx%d\n", width, height);
+			glBindFramebuffer(GL_FRAMEBUFFER, 0);
+			return false;
+		}
+	} else {
+		glBindFramebuffer(GL_FRAMEBUFFER, flip_fbo_);
+	}
+
+	glViewport(0, 0, width, height);
+	// Flip pass never uses sRGB framebuffer encoding — the frame is already
+	// in its target color space.
+	glDisable(GL_FRAMEBUFFER_SRGB);
+
+	glUseProgram(flip_program_);
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, source_texture_);
+	if (flip_u_source_ >= 0) {
+		glUniform1i(flip_u_source_, 0);
+	}
+
+	glBindVertexArray(shared_vao_);
+	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+	glBindVertexArray(0);
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	return true;
 }
 
 // ---- Uniform and Texture Binding ----
@@ -803,17 +985,7 @@ void ShaderPreset::render(const unsigned char* pixels, int width, int height, in
 	glDisable(GL_BLEND);
 	glDisable(GL_SCISSOR_TEST);
 
-	// Create/update original input texture
-	if (original_texture_ == 0) {
-		glGenTextures(1, &original_texture_);
-		glBindTexture(GL_TEXTURE_2D, original_texture_);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	}
-
-	// Determine pixel format
+	// Determine pixel format for the raw Amiga surface upload.
 	GLenum gl_fmt = GL_RGBA;
 	GLenum gl_type = GL_UNSIGNED_BYTE;
 	int bpp = 4;
@@ -832,47 +1004,43 @@ void ShaderPreset::render(const unsigned char* pixels, int width, int height, in
 		bpp = 2;
 	}
 
-	// Upload Amiga frame to original texture, flipping rows so that the
-	// texture matches OpenGL convention (row 0 = bottom of image).
-	// SDL provides top-down pixel data (row 0 = top), so we upload each row
-	// in reverse order. This ensures RetroArch shaders see the image in
-	// the expected orientation with standard texture coordinates.
+	// Upload the Amiga frame top-down (no CPU row reversal). The flip is
+	// performed on the GPU via run_flip_pass() below, avoiding a per-frame
+	// full-surface memcpy (~8 MB at 1080p × 32 bpp).
+	if (source_texture_ == 0) {
+		glGenTextures(1, &source_texture_);
+		glBindTexture(GL_TEXTURE_2D, source_texture_);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, original_texture_);
+	glBindTexture(GL_TEXTURE_2D, source_texture_);
 	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, pitch / bpp);
 
-	bool size_changed = (width != original_width_ || height != original_height_);
+	const bool size_changed = (width != original_width_ || height != original_height_);
 	if (size_changed) {
 		original_width_ = width;
 		original_height_ = height;
-		// Resize flip buffer
-		flip_buffer_.resize(static_cast<size_t>(width) * bpp * height);
-	}
-
-	// Flip rows into temporary buffer so the texture matches GL convention
-	// (row 0 = bottom of image). SDL provides top-down pixel data.
-	{
-		const int src_pitch = pitch;
-		const int dst_pitch = width * bpp;
-		const unsigned char* src_ptr = pixels;
-		unsigned char* dst_ptr = flip_buffer_.data();
-		for (int row = 0; row < height; row++) {
-			const unsigned char* src_row = src_ptr + row * src_pitch;
-			unsigned char* dst_row = dst_ptr + (height - 1 - row) * dst_pitch;
-			memcpy(dst_row, src_row, dst_pitch);
-		}
-	}
-
-	// Upload the flipped buffer in one call
-	glPixelStorei(GL_UNPACK_ROW_LENGTH, width);
-	if (size_changed) {
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0,
-			gl_fmt, gl_type, flip_buffer_.data());
+			gl_fmt, gl_type, pixels);
 	} else {
 		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height,
-			gl_fmt, gl_type, flip_buffer_.data());
+			gl_fmt, gl_type, pixels);
 	}
 	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+	// Produce the correctly-oriented original_texture_ for user passes by
+	// running the internal Y-flip pass. Must happen after source_texture_
+	// is up-to-date and before any user pass reads OrigTexture.
+	if (!run_flip_pass(width, height)) {
+		// Flip pass failed (e.g. shader compile error); drop the frame
+		// rather than render an upside-down image.
+		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+		return;
+	}
 
 	// Render each pass
 	int pass_count = static_cast<int>(passes_.size());
@@ -941,36 +1109,14 @@ void ShaderPreset::render(const unsigned char* pixels, int width, int height, in
 		// must happen here in the render loop where the correct GL context is active.
 		pass.shader->apply_parameter_uniforms();
 
-		// Draw fullscreen quad
+		// Draw fullscreen quad. Attribute layout is baked into the VAO
+		// (see setup_shared_vertex_data), so we only need to bind it.
 		glBindVertexArray(shared_vao_);
-		glBindBuffer(GL_ARRAY_BUFFER, shared_vbo_);
-
-		const GLsizei stride = 8 * sizeof(float);
-
-		glDisableVertexAttribArray(0);
-		glDisableVertexAttribArray(1);
-		glDisableVertexAttribArray(2);
-
-		// Attribute 0: VertexCoord (vec4)
-		glEnableVertexAttribArray(0);
-		glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, stride, nullptr);
-
-		// Attribute 1: Color (constant white)
-		glVertexAttrib4f(1, 1.0f, 1.0f, 1.0f, 1.0f);
-
-		// Attribute 2: TexCoord (vec2)
-		glEnableVertexAttribArray(2);
-		glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, (void*)(4 * sizeof(float)));
-
 		glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-
-		glDisableVertexAttribArray(0);
-		glDisableVertexAttribArray(2);
 	}
 
 	// Cleanup
 	glDisable(GL_FRAMEBUFFER_SRGB);
-	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindVertexArray(0);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);

--- a/src/osdep/shader_preset.h
+++ b/src/osdep/shader_preset.h
@@ -119,6 +119,12 @@ private:
 		int& out_w, int& out_h);
 	bool load_lut_texture(LutTexture& lut);
 	void setup_shared_vertex_data();
+	// One-time GL resources for the internal Y-flip pre-pass. Compiled on
+	// first use. See the comment above flip_program_ for why this exists.
+	bool ensure_flip_resources();
+	// Render source_texture_ into original_texture_ via flip_fbo_, applying
+	// a Y-flip so that all user passes see the frame in GL convention.
+	bool run_flip_pass(int width, int height);
 	void cleanup();
 
 	// Uniform and texture binding for a pass
@@ -131,17 +137,32 @@ private:
 	std::vector<LutTexture> lut_textures_;
 	std::vector<ShaderParameter> all_parameters_;
 
-	// Original input texture (Amiga frame)
+	// Raw Amiga frame texture (uploaded directly from the top-down SDL
+	// surface, no CPU flip). Feeds the internal flip pass.
+	GLuint source_texture_ = 0;
+	// Original input texture (Amiga frame) in RetroArch / GL convention
+	// (row 0 at bottom-left). Populated each frame by the flip pass and
+	// exposed to user passes via the `OrigTexture` sampler.
 	GLuint original_texture_ = 0;
 	int original_width_ = 0;
 	int original_height_ = 0;
 
-	// Shared vertex resources
+	// Shared vertex resources — single quad in clip space used by all passes.
+	// Vertex attribute pointers are configured inside the VAO once at
+	// creation, so per-pass rendering only needs to bind the VAO.
 	GLuint shared_vbo_ = 0;
 	GLuint shared_vao_ = 0;
 
-	// Buffer for flipping pixel rows during texture upload
-	std::vector<unsigned char> flip_buffer_;
+	// Internal Y-flip pre-pass GL resources. The SDL Amiga surface is
+	// top-down (row 0 at top), but RetroArch shaders expect GL-convention
+	// input (row 0 at bottom). Instead of copying the whole frame every
+	// frame on the CPU to flip rows, we upload it as-is to source_texture_
+	// and do the flip on the GPU in a single trivial pre-pass, writing the
+	// properly-oriented image into original_texture_.
+	GLuint flip_program_ = 0;
+	GLuint flip_fbo_ = 0;
+	// Cached uniform location for the flip shader's texture sampler.
+	GLint flip_u_source_ = -1;
 
 	std::string preset_path_;
 	std::string base_dir_;

--- a/src/osdep/shader_preset.h
+++ b/src/osdep/shader_preset.h
@@ -163,6 +163,14 @@ private:
 	GLuint flip_fbo_ = 0;
 	// Cached uniform location for the flip shader's texture sampler.
 	GLint flip_u_source_ = -1;
+	// Current allocation size of original_texture_. Kept separate from
+	// original_width_/original_height_ (which track source upload size) so
+	// that recreating original_texture_ forces a re-allocation via
+	// glTexImage2D + FBO attachment even when the source size is unchanged.
+	// Must be a member (not a function-local static in run_flip_pass) so
+	// that multiple ShaderPreset instances do not share one cache.
+	int flip_dest_w_ = 0;
+	int flip_dest_h_ = 0;
 
 	std::string preset_path_;
 	std::string base_dir_;


### PR DESCRIPTION
## Summary

Two related but separable topics bundled here so they can be tested together on the same branch.

### 1. Zero-copy RTG refresh holes (fixes symptoms in BlitterStudio/amiberry#1972)

Reporter's scenario: Workbench in a uaegfx RTG mode with ZeroCopy + Lightwave promoted to the same resolution via ModePro. Three symptoms:
- mouse lag in LW Modeler 2D viewports
- after closing LW, Workbench doesn't refresh until a window is moved
- parts of an imp3 (WB) window bleed onto the LW screen

Four underlying issues found by tracing the zero-copy and dirty-tracking paths:

1. `picasso_SetPanning` didn't set `picasso_zero_copy_update_needed` — only `SetDisplay` did. Subsequent Picasso screen switches (the common WB ↔ LW case) never go through `SetSwitch`/`SetDisplay`, so the host surface could stay bound to the previous screen's VRAM.
2. The panning-triggered `target_graphics_buffer_update` was called with `force=false`, letting the early-return shortcut skip the rebind when the new screen happened to land at the same host VA.
3. The zero-copy refresh consumer in `amiberry_renderframe` was wrapped in `#ifdef WITH_THREADED_CPU` despite being unrelated to that feature — latent foot-gun if the define ever goes away.
4. `gfxmem*_lput/wput/bput` (from `MEMORY_FUNCTIONS`) did not call `mark_dirty()`, so direct CPU writes to RTG VRAM (LW's 2D viewports, imp3's custom window rendering, most software renderers and games) were invisible to `picasso_getwritewatch`. This hit SDL/Vulkan renderers hardest (OpenGL happens to re-upload the whole surface every frame so it masks the symptom there).

Native WinUAE on Windows is untouched — it still uses the OS-level `GetWriteWatch` path.

### 2. OpenGL render-path perf

The OpenGL backend is the default and had a fair amount of per-frame setup work that belongs one-shot.

**`render_external_shader`** — removed:
- four `glIs*` validation calls per frame (driver round-trips)
- `glBufferData` reuploading identical fullscreen-quad vertices every frame
- per-frame attrib enable/disable/pointer dance (that's what the VAO is for)
- duplicate `glDisable(DEPTH/CULL/BLEND/SCISSOR)` (already done by `present_frame`'s baseline)
- stack-allocated identity MVP matrix every frame

**`ShaderPreset::render`** — the big one:
- per-frame CPU vertical flip of the entire Amiga surface (~8 MB memcpy per frame at 1920x1080x32bpp, ~480 MB/s at 60 fps) replaced with a trivial GPU pre-pass that samples the top-down upload with Y-inverted texcoords. `OrigTexture` semantics and the whole multi-pass user API are unchanged.
- attribute layout now baked into the shared VAO, removing the enable/disable/pointer sequence from the inner per-pass loop.

## Commits

- `fix(rtg): close zero-copy refresh holes causing Lightwave artifacts`
- `perf(opengl): hoist one-time state out of render_external_shader`
- `perf(opengl): replace shader-preset CPU Y-flip with GPU pre-pass`

Each commit is self-contained and can be reverted independently.

## Test plan

- [x] Default OpenGL build still renders the native Amiga chipset correctly at 50/60 Hz, no orientation/color regressions
- [x] RTG display works with: `none` shader, a built-in CRT shader, an external `.glsl` shader, and a multi-pass `.glslp` preset (the last one exercises the new flip pass)
- [x] Zero-copy ON (Chipset panel) + RTG at 32bpp: boot into WB, verify normal use has no regressions
- [ ] Repro for #1972 on Windows OpenGL build:
    - [x] WB in uaegfx + ZeroCopy at 1920x1080, open/close Lightwave promoted to same res → WB redraws cleanly
    - [ ] imp3 on WB + LW open → no WB window content visible on LW screen
    - [ ] LW Modeler with 3 2D viewports → mouse no longer lags
- [x] SDL renderer build (`-DUSE_OPENGL=OFF`) still works for native + RTG
- [x] Vulkan renderer build (`-DUSE_OPENGL=OFF -DUSE_VULKAN=ON`) still works (unrelated pre-existing build error in `vulkan_renderer.cpp:1699` — `monid` reference — is not addressed here)
- [x] Shader parameter sliders in the GUI still take effect (exercises `apply_parameter_uniforms`)