### PR TITLE
feat(input): map WEST face button as extra Joy Up (FS-UAE style)

### DIFF
--- a/src/include/options.h
+++ b/src/include/options.h
@@ -1087,6 +1087,7 @@ struct uae_prefs {
 	bool input_advancedmultiinput;
 	bool input_multi_mouse;
 	bool input_default_onscreen_keyboard;
+	bool input_joystick_up_button;
 	struct uae_input_device joystick_settings[MAX_INPUT_SETTINGS][MAX_INPUT_DEVICES];
 	struct uae_input_device mouse_settings[MAX_INPUT_SETTINGS][MAX_INPUT_DEVICES];
 	struct uae_input_device keyboard_settings[MAX_INPUT_SETTINGS][MAX_INPUT_DEVICES];

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -1067,6 +1067,7 @@ void write_inputdevice_config (struct uae_prefs *p, struct zfile *f)
 	cfgfile_dwrite_bool(f, _T("input.advancedmultiinput"), p->input_advancedmultiinput);
 	cfgfile_dwrite_bool(f, _T("input.multi_mouse"), p->input_multi_mouse);
 	cfgfile_dwrite_bool(f, _T("input.default_osk"), p->input_default_onscreen_keyboard);
+	cfgfile_dwrite_bool(f, _T("input.joystick_up_button"), p->input_joystick_up_button);
 #ifndef AMIBERRY // not used in Amiberry
 	for (id = 0; id < MAX_INPUT_SETTINGS; id++) {
 		TCHAR tmp[MAX_DPATH];
@@ -1632,6 +1633,8 @@ void read_inputdevice_config (struct uae_prefs *pr, const TCHAR *option, TCHAR *
 		pr->input_multi_mouse = !_tcsicmp(value, _T("true")) || _tstol(value) != 0;
 	if (!_tcsicmp(p, _T("default_osk")))
 		pr->input_default_onscreen_keyboard = !_tcsicmp(value, _T("true")) || _tstol(value) != 0;
+	if (!_tcsicmp(p, _T("joystick_up_button")))
+		pr->input_joystick_up_button = !_tcsicmp(value, _T("true")) || _tstol(value) != 0;
 	if (!_tcsicmp(p, _T("keyboard_type"))) {
 		cfgfile_strval(p, value, p, &pr->input_keyboard_type, kbtypes, 0);
 		keyboard_default = keyboard_default_table[pr->input_keyboard_type];
@@ -8540,6 +8543,7 @@ void inputdevice_default_prefs (struct uae_prefs *p)
 	p->input_device_match_mask = -1;
 	keyboard_default = keyboard_default_table[p->input_keyboard_type];
 	p->input_default_onscreen_keyboard = true;
+	p->input_joystick_up_button = true;
 	inputdevice_default_kb_all (p);
 
 }

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -9346,6 +9346,7 @@ void inputdevice_copyconfig (struct uae_prefs *src, struct uae_prefs *dst)
 	dst->input_mouse_speed = src->input_mouse_speed;
 	dst->input_autofire_linecnt = src->input_autofire_linecnt;
 	dst->input_multi_mouse = src->input_multi_mouse;
+	dst->input_joystick_up_button = src->input_joystick_up_button;
 #ifdef AMIBERRY
 	strcpy(dst->open_gui, src->open_gui);
 	strcpy(dst->quit_amiberry, src->quit_amiberry);

--- a/src/osdep/amiberry_input.cpp
+++ b/src/osdep/amiberry_input.cpp
@@ -1995,6 +1995,19 @@ int input_get_default_joystick(struct uae_input_device* uid, int i, int port, in
 			if (!button_map[0][SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER])
 				setid(uid, i, ID_BUTTON_OFFSET + SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER, 0, port, INPUTEVENT_KEY_RETURN, gp);
 		}
+
+		// FS-UAE-style extra Up bind on WEST (X/Square) so modern pads get a free jump button.
+		// Applies only in real joystick modes on ports 0/1; in DEFAULT mode this overrides the
+		// rarely-used 3rd fire button. Respect any user-defined custom mapping on WEST.
+		// Analog mode has its own default-mapping function (input_get_default_joystick_analog).
+		if (currprefs.input_joystick_up_button
+			&& port < 2
+			&& (mode == JSEM_MODE_DEFAULT || mode == JSEM_MODE_JOYSTICK)
+			&& !button_map[0][SDL_GAMEPAD_BUTTON_WEST])
+		{
+			setid(uid, i, ID_BUTTON_OFFSET + SDL_GAMEPAD_BUTTON_WEST, 0, port,
+				port ? INPUTEVENT_JOY2_UP : INPUTEVENT_JOY1_UP, gp);
+		}
 	}
 
 	// Set the events for any Custom Controls mapping

--- a/src/osdep/imgui/input.cpp
+++ b/src/osdep/imgui/input.cpp
@@ -282,6 +282,15 @@ void render_panel_input() {
             joystick_refresh_needed = false;
         }
 
+        ImGui::TableNextRow();
+        ImGui::TableNextColumn(); // Skip Col 1
+        ImGui::TableNextColumn();
+        AmigaCheckbox("Map left face button (Xbox X / PS Square) as extra Joy Up", &changed_prefs.input_joystick_up_button);
+        ShowHelpMarker("Binds the left face button (Xbox X / PlayStation Square) as a duplicate of "
+                       "Joystick Up on Joystick and Default port modes, giving a free dedicated jump "
+                       "button on modern gamepads. In Default mode this overrides the rarely-used "
+                       "3rd fire button. Does not apply to CD32 or Gamepad modes.");
+
         ImGui::EndTable();
     }
     ImGui::Spacing();


### PR DESCRIPTION
## Summary

Adds a free, dedicated jump button on modern gamepads by binding the **left face button (Xbox X / PlayStation Square)** as a duplicate of **Joystick Up** when the port is in *Default* or *Joystick* mode. This mirrors FS-UAE's long-standing behavior and makes Amiga platformers (Turrican, Lionheart, etc.) far more comfortable on modern controllers without requiring per-game rebinds.

## Behavior

- New preference `input.joystick_up_button` (default **on**), exposed as a checkbox in the Input panel.
- Applies on **ports 0/1 only** in these modes: `JSEM_MODE_DEFAULT`, `JSEM_MODE_JOYSTICK`.
- **Excluded** modes: `GAMEPAD`, `JOYSTICK_CD32`, `JOYSTICK_ANALOG` (analog has its own default-mapping function and already assigns Up to button 2), `MOUSE`, `MOUSE_CDTV`, and parallel-port joystick adapters.
- Respects any existing user-defined custom mapping on WEST (`button_map[0][WEST]`).
- In **Default** mode the bind overrides the rarely-used 3rd fire button (`setid` last-write-wins). In **Joystick** mode WEST was previously unbound so this is a pure addition.

## Files changed

- `src/include/options.h` — add `bool input_joystick_up_button` to `struct uae_prefs`.
- `src/inputdevice.cpp` — parse/save `input.joystick_up_button`; default to `true` in `inputdevice_default_prefs()`.
- `src/osdep/amiberry_input.cpp` — new WEST→Joy*_UP `setid()` call in `input_get_default_joystick()`, placed after the existing START/LShoulder/RShoulder default mappings.
- `src/osdep/imgui/input.cpp` — checkbox with tooltip in the Input panel.

## Test plan

- [ ] Launch a platformer (Turrican II, Lionheart) in **Default** port mode with a gamepad: X/Square should trigger jump as a duplicate of Up.
- [ ] Switch the port to **Joystick** mode: X/Square still jumps.
- [ ] Switch to **CD32** mode: X/Square goes back to CD32 Green (feature correctly excluded).
- [ ] Switch to **Gamepad** mode: X/Square goes back to 3rd fire (feature correctly excluded).
- [ ] Custom-map WEST to something in the Input custom mappings: custom mapping wins, extra-Up is not applied.
- [ ] Toggle the checkbox off, click OK: behaviour reverts to previous (WEST=3rd fire in Default, unbound in Joystick).
- [ ] Round-trip: save a config with the option disabled, reload, verify the key persists.

Fixes #1968