### PR TITLE
fix(input): clear keyboard reset state in inputdevice_reset()

### DIFF
--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -5918,7 +5918,7 @@ void inputdevice_vsync (void)
 			pausemode(1);
 		}
 	}
-	if (keyboard_reset_seq_mode && keyboard_reset_seq > 0) {
+	if (keyboard_reset_seq_mode) {
 		keyboard_reset_seq++;
 	}
 
@@ -5960,6 +5960,8 @@ void inputdevice_reset (void)
 	mousehack_reset ();
 	if (inputdevice_is_tablet ())
 		mousehack_enable ();
+	keyboard_reset_seq = 0;
+	keyboard_reset_seq_mode = 0;
 	bouncy = 0;
 	while (delayed_events) {
 		struct delayed_event *de = delayed_events;


### PR DESCRIPTION
On any chipset with reset-warning support (e.g. A4000), Ctrl-Amiga-Amiga puts keyboard_reset_seq_mode into state 3 for a 10s OS housekeeping window. AmigaOS exits the window by clearing SP=output on CIA-A, which routes through inputdevice_do_kb_reset() and clears the mode. AROS instead executes the m68k RESET instruction directly, going cpureset() -> custom_reset_cpu() -> custom_reset() -> inputdevice_reset(). That path never cleared the mode, so it stayed at 3 across the reset and inputdevice_do_keyboard() ate every subsequent keystroke, leaving the keyboard permanently stuck until a full emulator restart.

Clear keyboard_reset_seq and keyboard_reset_seq_mode in inputdevice_reset() so any reset path leaves the input layer clean.

Also drop the `keyboard_reset_seq > 0` guard on the vsync counter: it's zeroed when entering a reset-warning mode and needs to tick from the first vsync to reach the 15*50 timeout. The guard pinned it at 0, so modes 3/4 could only exit via explicit events, never by timeout.

Fixes #1971.
