### PR TITLE
Fix VSync regression on matched monitor refresh (#1985)

### DIFF
--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 
 #include "options.h"
 #include "threaddep/thread.h"
@@ -2494,7 +2495,8 @@ void drawing_init(void)
 }
 
 #if defined(AMIBERRY) && !defined(LIBRETRO)
-extern float amiberry_get_active_display_refreshrate(int monid);
+extern uint32_t amiberry_get_active_display_id(int monid);
+extern float amiberry_get_refreshrate_for_display_id(uint32_t display_id);
 
 // Returns true when the host monitor refresh matches the Amiga chipset target
 // within ~1 Hz, so SDL_GL_SwapWindow / SDL_RenderPresent blocking on the next
@@ -2508,11 +2510,11 @@ extern float amiberry_get_active_display_refreshrate(int monid);
 // The Vulkan renderer's present path does not block on vblank (see
 // vulkan_renderer.cpp), so hardware pacing is disabled there unconditionally.
 //
-// The result is cached keyed on vblank_hz; a SDL query runs only when the
-// Amiga target refresh changes (PAL/NTSC switch, genlock, etc.) or when the
-// previous query failed (SDL not yet initialized — retry next call).
-// Changing the monitor refresh mid-session requires a config change that
-// moves vblank_hz or an emulator restart to be picked up.
+// The result is cached keyed on (vblank_hz, active-display-id). The display-id
+// is queried every call (cheap: SDL_GetDisplayForWindow is an O(1) lookup),
+// so dragging the window to another monitor or PAL/NTSC switches both
+// correctly invalidate the cache. The refresh-rate lookup itself only runs
+// on a miss.
 static bool amiberry_hw_vsync_pacing_ok(void)
 {
 #ifdef USE_VULKAN
@@ -2520,22 +2522,29 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 #else
 	// Sentinel: cached_vblank_hz <= 0 means "no successful probe yet" (or the
 	// previous probe failed). A successful probe — even one that reported a
-	// mismatch — stores the real vblank_hz so we don't re-query every frame.
+	// mismatch — stores vblank_hz + display_id so we don't re-query every frame.
 	static float cached_vblank_hz = -1.0f;
+	static uint32_t cached_display_id = 0;
 	static bool cached_result = false;
 	if (vblank_hz <= 0.0f)
 		return false;
+	const uint32_t display_id = amiberry_get_active_display_id(0);
+	if (!display_id)
+		return false;  // Window / display not resolvable yet, try again next call.
 	const bool probe_pending = (cached_vblank_hz <= 0.0f);
 	const bool vblank_changed = !probe_pending && std::fabs(cached_vblank_hz - vblank_hz) > 0.01f;
-	if (probe_pending || vblank_changed) {
-		const float monitor_hz = amiberry_get_active_display_refreshrate(0);
+	const bool display_changed = !probe_pending && cached_display_id != display_id;
+	if (probe_pending || vblank_changed || display_changed) {
+		const float monitor_hz = amiberry_get_refreshrate_for_display_id(display_id);
 		if (monitor_hz <= 0.0f) {
-			// SDL not ready / no display — keep sentinel so next call retries.
+			// SDL not ready yet — keep sentinel so next call retries.
 			cached_vblank_hz = -1.0f;
+			cached_display_id = 0;
 			cached_result = false;
 			return false;
 		}
 		cached_vblank_hz = vblank_hz;
+		cached_display_id = display_id;
 		cached_result = (std::fabs(monitor_hz - vblank_hz) < 1.0f);
 	}
 	return cached_result;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -15,6 +15,7 @@
 #include "sysdeps.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cassert>
 #include <cmath>
@@ -2495,8 +2496,31 @@ void drawing_init(void)
 }
 
 #if defined(AMIBERRY) && !defined(LIBRETRO)
-extern uint32_t amiberry_get_active_display_id(int monid);
-extern float amiberry_get_refreshrate_for_display_id(uint32_t display_id);
+// Cached host-monitor refresh rate in millihertz. Written ONLY on the SDL
+// main thread via amiberry_hw_vsync_pacing_invalidate(); read on the
+// emulator thread by amiberry_hw_vsync_pacing_ok(). 0 means "not probed
+// yet" or "probe failed / display not ready". Millihertz (×1000) lets us
+// use std::atomic<uint32_t> (guaranteed lock-free on all targets) instead
+// of std::atomic<float>, with enough precision for a ~1 Hz match tolerance.
+static std::atomic<uint32_t> hw_vsync_cached_monitor_hz_x1000{0};
+
+// Invoked on the SDL main thread in response to display / window events
+// (window migrated to another display, display mode changed) and once at
+// graphics_init() time. Re-probes SDL and caches the active display's
+// refresh rate for the emulator thread. SDL3's SDL_GetDisplayForWindow /
+// SDL_GetCurrentDisplayMode are documented as main-thread-only, so this
+// function must only be called from the main thread.
+void amiberry_hw_vsync_pacing_invalidate(void)
+{
+	const uint32_t display_id = amiberry_get_active_display_id(0);
+	const float monitor_hz = display_id
+		? amiberry_get_refreshrate_for_display_id(display_id)
+		: 0.0f;
+	const uint32_t hz_x1000 = monitor_hz > 0.0f
+		? static_cast<uint32_t>(monitor_hz * 1000.0f + 0.5f)
+		: 0;
+	hw_vsync_cached_monitor_hz_x1000.store(hz_x1000, std::memory_order_relaxed);
+}
 
 // Returns true when the host monitor refresh matches the Amiga chipset target
 // within ~1 Hz, so SDL_GL_SwapWindow / SDL_RenderPresent blocking on the next
@@ -2510,46 +2534,27 @@ extern float amiberry_get_refreshrate_for_display_id(uint32_t display_id);
 // The Vulkan renderer's present path does not block on vblank (see
 // vulkan_renderer.cpp), so hardware pacing is disabled there unconditionally.
 //
-// The result is cached keyed on (vblank_hz, active-display-id). The display-id
-// is queried every call (cheap: SDL_GetDisplayForWindow is an O(1) lookup),
-// so dragging the window to another monitor or PAL/NTSC switches both
-// correctly invalidate the cache. The refresh-rate lookup itself only runs
-// on a miss.
+// This runs on the emulator thread (via isvsync_chipset() → framewait()).
+// It does NOT call any SDL video APIs: it only reads the cached monitor Hz
+// published by amiberry_hw_vsync_pacing_invalidate() on the main thread.
 static bool amiberry_hw_vsync_pacing_ok(void)
 {
 #ifdef USE_VULKAN
 	return false;
 #else
-	// Sentinel: cached_vblank_hz <= 0 means "no successful probe yet" (or the
-	// previous probe failed). A successful probe — even one that reported a
-	// mismatch — stores vblank_hz + display_id so we don't re-query every frame.
-	static float cached_vblank_hz = -1.0f;
-	static uint32_t cached_display_id = 0;
-	static bool cached_result = false;
 	if (vblank_hz <= 0.0f)
 		return false;
-	const uint32_t display_id = amiberry_get_active_display_id(0);
-	if (!display_id)
-		return false;  // Window / display not resolvable yet, try again next call.
-	const bool probe_pending = (cached_vblank_hz <= 0.0f);
-	const bool vblank_changed = !probe_pending && std::fabs(cached_vblank_hz - vblank_hz) > 0.01f;
-	const bool display_changed = !probe_pending && cached_display_id != display_id;
-	if (probe_pending || vblank_changed || display_changed) {
-		const float monitor_hz = amiberry_get_refreshrate_for_display_id(display_id);
-		if (monitor_hz <= 0.0f) {
-			// SDL not ready yet — keep sentinel so next call retries.
-			cached_vblank_hz = -1.0f;
-			cached_display_id = 0;
-			cached_result = false;
-			return false;
-		}
-		cached_vblank_hz = vblank_hz;
-		cached_display_id = display_id;
-		cached_result = (std::fabs(monitor_hz - vblank_hz) < 1.0f);
-	}
-	return cached_result;
+	const uint32_t hz_x1000 = hw_vsync_cached_monitor_hz_x1000.load(std::memory_order_relaxed);
+	if (hz_x1000 == 0)
+		return false;  // Main thread hasn't probed yet (or the probe failed).
+	const float monitor_hz = static_cast<float>(hz_x1000) / 1000.0f;
+	return std::fabs(monitor_hz - vblank_hz) < 1.0f;
 #endif
 }
+#elif defined(AMIBERRY)
+// Libretro stub: declaration is visible via xwin.h's AMIBERRY block, so
+// provide an empty body here so callers link without the full pacing logic.
+void amiberry_hw_vsync_pacing_invalidate(void) {}
 #endif
 
 int isvsync_chipset(void)

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cassert>
+#include <cmath>
 
 #include "options.h"
 #include "threaddep/thread.h"
@@ -2492,16 +2493,70 @@ void drawing_init(void)
 	reset_drawing();
 }
 
+#if defined(AMIBERRY) && !defined(LIBRETRO)
+extern float amiberry_getrefreshrate(int monid);
+
+// Returns true when the host monitor refresh matches the Amiga chipset target
+// within ~1 Hz, so SDL_GL_SwapWindow / SDL_RenderPresent blocking on the next
+// vblank paces the emulator at the correct rate. When this is true we can
+// safely use the vs>0 framewait() path (hardware pacing) which preserves
+// smooth scrolling on matched setups (e.g. 50 Hz monitor + PAL). When false,
+// framewait() stays on the software-timing path — this avoids the #1947
+// audio-delay scenario (60 Hz monitor + 50 Hz PAL game: swap-block would
+// pace at 60 Hz).
+//
+// The Vulkan renderer's present path does not block on vblank (see
+// vulkan_renderer.cpp), so hardware pacing is disabled there unconditionally.
+//
+// The result is cached keyed on vblank_hz; a SDL query runs only when the
+// Amiga target refresh changes (PAL/NTSC switch, genlock, etc.) or when the
+// previous query failed (SDL not yet initialized — retry next call).
+// Changing the monitor refresh mid-session requires a config change that
+// moves vblank_hz or an emulator restart to be picked up.
+static bool amiberry_hw_vsync_pacing_ok(void)
+{
+#ifdef USE_VULKAN
+	return false;
+#else
+	// Sentinel: cached_vblank_hz <= 0 means "no successful probe yet" (or the
+	// previous probe failed). A successful probe — even one that reported a
+	// mismatch — stores the real vblank_hz so we don't re-query every frame.
+	static float cached_vblank_hz = -1.0f;
+	static bool cached_result = false;
+	if (vblank_hz <= 0.0f)
+		return false;
+	const bool probe_pending = (cached_vblank_hz <= 0.0f);
+	const bool vblank_changed = !probe_pending && std::fabs(cached_vblank_hz - vblank_hz) > 0.01f;
+	if (probe_pending || vblank_changed) {
+		const float monitor_hz = amiberry_getrefreshrate(0);
+		if (monitor_hz <= 0.0f) {
+			// SDL not ready / no display — keep sentinel so next call retries.
+			cached_vblank_hz = -1.0f;
+			cached_result = false;
+			return false;
+		}
+		cached_vblank_hz = vblank_hz;
+		cached_result = (std::fabs(monitor_hz - vblank_hz) < 1.0f);
+	}
+	return cached_result;
+#endif
+}
+#endif
+
 int isvsync_chipset(void)
 {
 	struct amigadisplay *ad = &adisplays[0];
 	if (ad->picasso_on || currprefs.gfx_apmode[0].gfx_vsync <= 0)
 		return 0;
 #ifdef AMIBERRY
-	// Amiberry uses software timing (vs==0 path) for frame pacing on all platforms.
-	// The renderer independently sets SwapInterval for tear prevention.
-	// The WinUAE vs>0 path relies on swap blocking matching the Amiga refresh rate,
-	// which requires exclusive fullscreen mode switching (D3D) not available via SDL/OpenGL.
+#ifndef LIBRETRO
+	// Standard VSync (gfx_vsyncmode == 0) with matched monitor refresh can use
+	// hardware pacing via swap blocking. Any other combination falls through to
+	// software timing — renderers still set SwapInterval independently for tear
+	// prevention.
+	if (currprefs.gfx_apmode[0].gfx_vsyncmode == 0 && amiberry_hw_vsync_pacing_ok())
+		return 1;
+#endif
 	return 0;
 #else
 	if (currprefs.gfx_apmode[0].gfx_vsyncmode == 0)
@@ -2518,6 +2573,9 @@ int isvsync_rtg(void)
 	if (!ad->picasso_on || currprefs.gfx_apmode[1].gfx_vsync <= 0)
 		return 0;
 #ifdef AMIBERRY
+	// RTG/Picasso modes run at their own refresh rate (often 60/70/75 Hz),
+	// not chipset vblank_hz. Until we plumb the right target refresh through,
+	// stay on software timing for RTG to preserve the #1947 fix.
 	return 0;
 #else
 	if (currprefs.gfx_apmode[1].gfx_vsyncmode == 0)

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -2494,7 +2494,7 @@ void drawing_init(void)
 }
 
 #if defined(AMIBERRY) && !defined(LIBRETRO)
-extern float amiberry_getrefreshrate(int monid);
+extern float amiberry_get_active_display_refreshrate(int monid);
 
 // Returns true when the host monitor refresh matches the Amiga chipset target
 // within ~1 Hz, so SDL_GL_SwapWindow / SDL_RenderPresent blocking on the next
@@ -2528,7 +2528,7 @@ static bool amiberry_hw_vsync_pacing_ok(void)
 	const bool probe_pending = (cached_vblank_hz <= 0.0f);
 	const bool vblank_changed = !probe_pending && std::fabs(cached_vblank_hz - vblank_hz) > 0.01f;
 	if (probe_pending || vblank_changed) {
-		const float monitor_hz = amiberry_getrefreshrate(0);
+		const float monitor_hz = amiberry_get_active_display_refreshrate(0);
 		if (monitor_hz <= 0.0f) {
 			// SDL not ready / no display — keep sentinel so next call retries.
 			cached_vblank_hz = -1.0f;
@@ -2550,11 +2550,14 @@ int isvsync_chipset(void)
 		return 0;
 #ifdef AMIBERRY
 #ifndef LIBRETRO
-	// Standard VSync (gfx_vsyncmode == 0) with matched monitor refresh can use
-	// hardware pacing via swap blocking. Any other combination falls through to
-	// software timing — renderers still set SwapInterval independently for tear
-	// prevention.
-	if (currprefs.gfx_apmode[0].gfx_vsyncmode == 0 && amiberry_hw_vsync_pacing_ok())
+	// Standard VSync (gfx_vsyncmode == 0, not Adaptive/VRR) with matched monitor
+	// refresh can use hardware pacing via swap blocking. Any other combination
+	// falls through to software timing — renderers still set SwapInterval
+	// independently for tear prevention. Adaptive (gfx_variable_sync=1) stays on
+	// software timing because SwapInterval=-1 doesn't guarantee blocking on
+	// late frames.
+	if (currprefs.gfx_apmode[0].gfx_vsyncmode == 0 && !currprefs.gfx_variable_sync
+		&& amiberry_hw_vsync_pacing_ok())
 		return 1;
 #endif
 	return 0;

--- a/src/include/xwin.h
+++ b/src/include/xwin.h
@@ -12,6 +12,10 @@
 #include "uae/types.h"
 #include "machdep/rpt.h"
 
+#ifdef AMIBERRY
+#include <cstdint>
+#endif
+
 typedef uae_u32 xcolnr;
 
 typedef int (*allocfunc_type)(int, int, int, xcolnr*);
@@ -45,6 +49,17 @@ extern void updatedisplayarea(int monid);
 extern int isvsync_chipset(void);
 extern int isvsync_rtg(void);
 extern int isvsync(void);
+
+#ifdef AMIBERRY
+// Display/refresh queries used by the hardware VSync pacing decision in
+// isvsync_chipset(). Defined in osdep/amiberry_gfx.cpp.
+extern uint32_t amiberry_get_active_display_id(int monid);
+extern float amiberry_get_refreshrate_for_display_id(uint32_t display_id);
+
+// Forces the hardware VSync pacing cache to re-probe on the next call. Called
+// from the SDL event loop on display mode / window-display changes.
+extern void amiberry_hw_vsync_pacing_invalidate(void);
+#endif
 
 extern void flush_line(struct vidbuffer*, int);
 extern void flush_block(struct vidbuffer*, int, int);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -2017,11 +2017,13 @@ static void handle_window_event(const SDL_Event& event, AmigaMonitor* mon)
 	case SDL_EVENT_WINDOW_MOVED:
 		handle_moved_event(mon);
 		break;
+#ifndef LIBRETRO
 	case SDL_EVENT_WINDOW_DISPLAY_CHANGED:
 		// Window migrated to a different display — force the hw VSync pacing
 		// decision to re-probe against the new display's refresh rate.
 		amiberry_hw_vsync_pacing_invalidate();
 		break;
+#endif
 	case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
 	case SDL_EVENT_WINDOW_RESIZED:
 		handle_resized_event(mon, event.window.data1, event.window.data2);
@@ -2833,6 +2835,7 @@ static void process_event(const SDL_Event& event)
 			handle_clipboard_update_event();
 			break;
 
+#ifndef LIBRETRO
 		case SDL_EVENT_DISPLAY_CURRENT_MODE_CHANGED:
 			// Display refresh-mode changed (user switched Hz in OS display
 			// settings, or HDMI re-linked at a new mode). Force the hw VSync
@@ -2840,6 +2843,7 @@ static void process_event(const SDL_Event& event)
 			// move or the Amiga target refresh to change.
 			amiberry_hw_vsync_pacing_invalidate();
 			break;
+#endif
 
 		case SDL_EVENT_JOYSTICK_ADDED:
 			handle_joy_device_event(event.jdevice.which, false, &currprefs);

--- a/src/osdep/amiberry.cpp
+++ b/src/osdep/amiberry.cpp
@@ -2017,6 +2017,11 @@ static void handle_window_event(const SDL_Event& event, AmigaMonitor* mon)
 	case SDL_EVENT_WINDOW_MOVED:
 		handle_moved_event(mon);
 		break;
+	case SDL_EVENT_WINDOW_DISPLAY_CHANGED:
+		// Window migrated to a different display — force the hw VSync pacing
+		// decision to re-probe against the new display's refresh rate.
+		amiberry_hw_vsync_pacing_invalidate();
+		break;
 	case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
 	case SDL_EVENT_WINDOW_RESIZED:
 		handle_resized_event(mon, event.window.data1, event.window.data2);
@@ -2826,6 +2831,14 @@ static void process_event(const SDL_Event& event)
 
 		case SDL_EVENT_CLIPBOARD_UPDATE:
 			handle_clipboard_update_event();
+			break;
+
+		case SDL_EVENT_DISPLAY_CURRENT_MODE_CHANGED:
+			// Display refresh-mode changed (user switched Hz in OS display
+			// settings, or HDMI re-linked at a new mode). Force the hw VSync
+			// pacing decision to re-probe without waiting for the window to
+			// move or the Amiga target refresh to change.
+			amiberry_hw_vsync_pacing_invalidate();
 			break;
 
 		case SDL_EVENT_JOYSTICK_ADDED:

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -263,6 +263,31 @@ float amiberry_getrefreshrate(const int monid)
 	return mode->refresh_rate;
 }
 
+// Returns the current refresh rate of the display actually hosting the
+// emulator window (tracks mid-session window drags across monitors), falling
+// back to the display configured via gfx_apmode[].gfx_display, and finally to
+// SDL display 0. Returns 0.0f if SDL video isn't initialized yet.
+float amiberry_get_active_display_refreshrate(const int monid)
+{
+	SDL_DisplayID display_id = 0;
+	if (monid >= 0 && monid < MAX_AMIGAMONITORS) {
+		const AmigaMonitor* mon = &AMonitors[monid];
+		if (mon->amiga_window)
+			display_id = SDL_GetDisplayForWindow(mon->amiga_window);
+	}
+	if (!display_id) {
+		const struct MultiDisplay* md = getdisplay(&currprefs, monid >= 0 ? monid : 0);
+		if (md)
+			display_id = md->display_id;
+	}
+	if (!display_id)
+		return 0.0f;
+	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_id);
+	if (!mode)
+		return 0.0f;
+	return mode->refresh_rate;
+}
+
 void GetWindowRect(SDL_Window* window, SDL_Rect* rect)
 {
 	SDL_GetWindowPosition(window, &rect->x, &rect->y);

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -1089,6 +1089,10 @@ int graphics_init(bool mousecapture)
 			gfxmode_reset(currprefs.monitoremu_mon);
 			open_windows(&AMonitors[currprefs.monitoremu_mon], mousecapture, false);
 		}
+		// Prime the hw VSync pacing cache on the main thread — the emulator
+		// thread reads the cached value but must not call SDL video APIs
+		// directly (SDL3 documents them as main-thread-only).
+		amiberry_hw_vsync_pacing_invalidate();
 		return true;
 	}
 	return false;

--- a/src/osdep/amiberry_gfx.cpp
+++ b/src/osdep/amiberry_gfx.cpp
@@ -263,29 +263,41 @@ float amiberry_getrefreshrate(const int monid)
 	return mode->refresh_rate;
 }
 
-// Returns the current refresh rate of the display actually hosting the
-// emulator window (tracks mid-session window drags across monitors), falling
-// back to the display configured via gfx_apmode[].gfx_display, and finally to
-// SDL display 0. Returns 0.0f if SDL video isn't initialized yet.
-float amiberry_get_active_display_refreshrate(const int monid)
+// Returns the SDL_DisplayID (as uint32_t) of the display hosting the emulator
+// window (tracks window drags across monitors), falling back to the configured
+// display, then to SDL display 0. Returns 0 if nothing is usable yet.
+uint32_t amiberry_get_active_display_id(const int monid)
 {
-	SDL_DisplayID display_id = 0;
 	if (monid >= 0 && monid < MAX_AMIGAMONITORS) {
 		const AmigaMonitor* mon = &AMonitors[monid];
-		if (mon->amiga_window)
-			display_id = SDL_GetDisplayForWindow(mon->amiga_window);
+		if (mon->amiga_window) {
+			const SDL_DisplayID id = SDL_GetDisplayForWindow(mon->amiga_window);
+			if (id)
+				return static_cast<uint32_t>(id);
+		}
 	}
-	if (!display_id) {
-		const struct MultiDisplay* md = getdisplay(&currprefs, monid >= 0 ? monid : 0);
-		if (md)
-			display_id = md->display_id;
-	}
+	const struct MultiDisplay* md = getdisplay(&currprefs, monid >= 0 ? monid : 0);
+	if (md && md->display_id)
+		return static_cast<uint32_t>(md->display_id);
+	return 0;
+}
+
+// Returns the current refresh rate for the given SDL_DisplayID, or 0.0f if
+// the display isn't known to SDL. Separated from id resolution so callers can
+// key a cache on the display id cheaply without re-probing the refresh.
+float amiberry_get_refreshrate_for_display_id(const uint32_t display_id)
+{
 	if (!display_id)
 		return 0.0f;
-	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(display_id);
-	if (!mode)
-		return 0.0f;
-	return mode->refresh_rate;
+	const SDL_DisplayMode* mode = SDL_GetCurrentDisplayMode(static_cast<SDL_DisplayID>(display_id));
+	return mode ? mode->refresh_rate : 0.0f;
+}
+
+// Returns the current refresh rate of the display actually hosting the
+// emulator window. Retained for callers that don't track the display id.
+float amiberry_get_active_display_refreshrate(const int monid)
+{
+	return amiberry_get_refreshrate_for_display_id(amiberry_get_active_display_id(monid));
 }
 
 void GetWindowRect(SDL_Window* window, SDL_Rect* rect)


### PR DESCRIPTION
## Summary
- Re-enables the hardware VSync pacing path (`vs>0` in `framewait()`) for Amiberry, but **only** when the host monitor refresh rate matches the Amiga target (`vblank_hz`) within 1 Hz.
- On matched setups (e.g. 50 Hz monitor + PAL game) this restores the 7.1.1 smooth-scrolling behavior that was lost in #1947's fix.
- On mismatched setups (e.g. 60 Hz monitor + 50 Hz PAL game) pacing stays on software timing — the #1947 audio-drift fix is preserved.

## Why the regression happened
Commit `d31202735` (fix for #1947) forced `isvsync_chipset()` / `isvsync_rtg()` to return `0` unconditionally on Amiberry, routing all pacing through software timing. That fixed the audio-delay case but lost the per-vblank swap-block pacing that 7.1.1 relied on when refresh rates aligned. Software timing alone can't align with the host vblank as tightly as `SDL_GL_SwapWindow` does on a matched refresh.

## How it works
- New helper `amiberry_hw_vsync_pacing_ok()` gates the hardware-pacing path. Triggers only for Standard VSync (`gfx_vsyncmode == 0`), excludes Adaptive/VRR (`gfx_variable_sync`).
- `isvsync_rtg()` stays at `0` — `vblank_hz` is the chipset target, not the RTG target, so RTG keeps software pacing conservatively.
- Disabled under `USE_VULKAN` (Vulkan present path doesn't block on vblank) and `LIBRETRO` (libretro has its own pacing layer).

## Thread safety / main-thread-only SDL video APIs
SDL3 documents `SDL_GetDisplayForWindow` / `SDL_GetCurrentDisplayMode` as main-thread-only. The pacing decision runs on the emulator thread via `isvsync_chipset()` → `framewait()`, so we split the logic:

- **Main thread** — `amiberry_hw_vsync_pacing_invalidate()` does the SDL probe and publishes the current display's refresh rate into `std::atomic<uint32_t> hw_vsync_cached_monitor_hz_x1000` (millihertz encoding, lock-free on all targets). Called:
  - Once at the end of `graphics_init()` to prime the cache before the emulator thread starts.
  - From the SDL event loop on `SDL_EVENT_WINDOW_DISPLAY_CHANGED` (window moved to another monitor).
  - From the SDL event loop on `SDL_EVENT_DISPLAY_CURRENT_MODE_CHANGED` (user switched Hz in OS settings / HDMI re-linked).
- **Emulator thread** — `amiberry_hw_vsync_pacing_ok()` only reads the atomic and compares with `vblank_hz`. No SDL calls on this path.

Sentinel of `hz_x1000 == 0` means "not probed yet / probe failed"; the pacing decision safely degrades to software timing until the main thread publishes a value.

## Behavior matrix
| Setup | Before this PR (8.1.x) | After this PR |
|---|---|---|
| 50 Hz monitor + PAL game, VSync Standard | Software timing, tearing/jerking | **Hardware pacing, smooth (7.1.1 behavior)** |
| 60 Hz monitor + PAL game, VSync Standard | Software timing, correct audio | Software timing, correct audio *(unchanged)* |
| 60 Hz monitor + NTSC game, VSync Standard | Software timing | **Hardware pacing, smooth** |
| Any Adaptive / VRR setting | Software timing | Software timing *(unchanged)* |
| RTG / Picasso | Software timing | Software timing *(unchanged)* |
| Vulkan renderer | Software timing | Software timing *(unchanged)* |

## Files touched
- `src/drawing.cpp` — new pacing helper + atomic cache + main-thread probe function.
- `src/include/xwin.h` — externs for the display helpers and the invalidate hook (under `#ifdef AMIBERRY`).
- `src/osdep/amiberry.cpp` — SDL event-loop hooks for `WINDOW_DISPLAY_CHANGED` and `DISPLAY_CURRENT_MODE_CHANGED`.
- `src/osdep/amiberry_gfx.cpp` — `amiberry_get_active_display_id()` / `amiberry_get_refreshrate_for_display_id()` helpers and the initial probe call at the end of `graphics_init()`.
- `wiki/GUI-Display.md` — documentation of the automatic matched/mismatched pacing behavior and cleaned-up obsolete Lagless entries.

## Review trail
- Oracle: clean on final form (thread safety, millihertz precision at 59.94 Hz, SDL event coverage).
- Codex P2 (initial): SDL display APIs on emulator thread → fixed by moving probe to main thread only.
- Codex P2 (multi-monitor): hardcoded display 0 → fixed by `SDL_GetDisplayForWindow` + `getdisplay()` fallback.
- Codex P2 (Adaptive VRR): Adaptive sets `gfx_vsync=1, gfx_vsyncmode=0, gfx_variable_sync=1` → gate excludes `gfx_variable_sync`.
- Codex P1 (cache ignored display changes): fixed by re-probing on `WINDOW_DISPLAY_CHANGED` / `DISPLAY_CURRENT_MODE_CHANGED` events.

## Test plan
- [ ] PAL game (Turrican II, Z-Out) on 50 Hz monitor — confirm smooth scrolling restored.
- [ ] PAL game on 60 Hz monitor — confirm audio stays in sync (no regression of #1947).
- [ ] NTSC game on 60 Hz monitor — confirm smooth scrolling.
- [ ] Switch PAL ↔ NTSC mid-session — confirm cache re-probes.
- [ ] Drag window across monitors with different refresh rates — confirm pacing updates.
- [ ] Switch OS display Hz mid-session — confirm pacing updates.
- [ ] Adaptive VSync mode — confirm software timing still used.
- [ ] RTG / Workbench mode — confirm behavior unchanged.
- [ ] Build: OpenGL, SDL fallback, Vulkan, libretro — all link and run.